### PR TITLE
fix(draft-contract): validator fields as defaults, not tokens (VA-154 follow-up)

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -17,16 +17,6 @@ Each entry:
 
 ## Open skill gaps
 
-### `/draft-contract`
-
-- **Purpose**: Given a Linear issue ID, lift intent into
-  `.goal-contract.draft.yml` with `<PLANNER_SUGGESTED:>` tokens on every
-  authority-bearing field. Per G8 of the governance plan, the draft is
-  structurally non-executable until a human replaces the tokens.
-- **Trigger-to-author**: First AFK pilot run. Needed before VA-154 ships.
-- **Classification**: skill.
-- **Tracking**: [VA-154](https://linear.app/valescoagency/issue/VA-154).
-
 ### `/attest`
 
 - **Purpose**: Render the attestation checklist from a `.goal-contract.yml`
@@ -108,4 +98,17 @@ in `valesco-platform/afk/`.
 
 ## Closed gaps
 
-_(none yet — entries move here from "Open" when authored + landed.)_
+### `/draft-contract` — shipped 2026-04-22
+
+- **Ships**: `draft-contract/SKILL.md`, `template.yml`, `authority-fields.md`.
+- **Tracking**: [VA-154](https://linear.app/valescoagency/issue/VA-154).
+- **Landed via**: PR [#1](https://github.com/ValescoAgency/skills/pull/1)
+  (initial) + follow-up to strict-validate drafts post-VA-158 merge.
+- **Notes**: Drafts now validate cleanly against
+  `afk/schemas/goal-contract.v1.json` thanks to
+  [VA-158](https://linear.app/valescoagency/issue/VA-158) (approvedAt +
+  contractHash optional at schema level; pre-flight's
+  `structural.metadata-presence` stage enforces presence). Validator
+  policyId / policyVersion emit as defaults with `# PLANNER_SUGGESTED`
+  comments rather than tokens, since string patterns can't hold token
+  strings — matches the tier/budget precedent.

--- a/draft-contract/authority-fields.md
+++ b/draft-contract/authority-fields.md
@@ -44,8 +44,6 @@ token; the human replaces it.
 | `intent.anchors.configShapes[]` | `<PLANNER_SUGGESTED: list config objects (e.g. OAuthConfig, SupabaseConfig) the contract depends on; empty array if none>` |
 | `scope.requiredPaths[]` | `<PLANNER_SUGGESTED: globs the agent is expected to touch; these must match real files at pre-flight. For migration contracts, supabase/migrations/** goes here, NOT merely in writePaths.>` |
 | `scope.writePaths[]` | `<PLANNER_SUGGESTED: globs the agent may modify; must include all requiredPaths. Default hard-floor + escalated-floor paths are never writable via this field.>` |
-| `scope.validator.policyId` | `<PLANNER_SUGGESTED: validator policy ID, e.g. valesco-platform.v1>` |
-| `scope.validator.policyVersion` | `<PLANNER_SUGGESTED: semver, e.g. 1.0.0>` |
 | `metadata.customer` (Tier 1 only) | `<PLANNER_SUGGESTED: customer identifier, e.g. acme-corp>` |
 | `canaryPlan.metrics[]` (Tier 1 only) | `<PLANNER_SUGGESTED: metrics to watch post-merge, e.g. error_rate, p95_latency>` |
 | `canaryPlan.rollbackTrigger` (Tier 1 only) | `<PLANNER_SUGGESTED: command or Vercel action to execute on rollback>` |
@@ -58,6 +56,8 @@ comments so the human sees they were not derived from the Linear issue.
 | Field | Default | Annotation |
 |---|---|---|
 | `metadata.tier` | `3` | `# PLANNER_SUGGESTED: default; raise to 2/1 per risk` |
+| `scope.validator.policyId` | `"valesco-platform.v1"` | `# PLANNER_SUGGESTED: default; change only if a per-repo policy exists` |
+| `scope.validator.policyVersion` | `"1.0.0"` | `# PLANNER_SUGGESTED: default; bump when the policy repo publishes a new version` |
 | `budget.timeMinutes` | `15` | `# PLANNER_SUGGESTED: Tier 3 default; widen with evidence` |
 | `budget.maxRetries` | `2` | `# PLANNER_SUGGESTED: Tier 3 default` |
 | `budget.maxCommits` | `5` | `# PLANNER_SUGGESTED: Tier 3 default` |

--- a/draft-contract/template.yml
+++ b/draft-contract/template.yml
@@ -43,8 +43,8 @@ scope:
   # the contract needs to protect paths beyond the floor.
   # protectedPaths: []
   validator:
-    policyId: "<PLANNER_SUGGESTED: validator policy ID, e.g. valesco-platform.v1>"
-    policyVersion: "<PLANNER_SUGGESTED: semver, e.g. 1.0.0>"
+    policyId: "valesco-platform.v1"   # PLANNER_SUGGESTED: default; change only if a per-repo policy exists
+    policyVersion: "1.0.0"            # PLANNER_SUGGESTED: default; bump when the policy repo publishes a new version
   # metaContract + sensitivePaths are computed by pre-flight — leave unset.
 
 budget:


### PR DESCRIPTION
## Summary

- Move `scope.validator.policyId` + `scope.validator.policyVersion` from `<PLANNER_SUGGESTED:>` tokens to defaulted values (`"valesco-platform.v1"` and `"1.0.0"`) with `# PLANNER_SUGGESTED` YAML comments. Token strings can't satisfy the semver pattern constraint on `policyVersion`; defaults with annotations match the existing tier/budget precedent.
- Close the loop on VA-154 in `docs/gaps.md` — entry moves to Closed gaps with a note explaining how VA-158 + this follow-up together let drafts strictly validate against `goal-contract.v1.json`.

## Test plan

- [x] AJV validation of a realistic `/draft-contract`-emitted draft (post-VA-158 schema, validator fields defaulted, token strings on path + anchor arrays) returns `valid: true` with zero errors.

Follow-up to VA-154 (already Done). No Linear ticket needed — closes the strict-validation acceptance criterion after VA-158 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)