### PR TITLE
feat(attest): walk checklist, write hash-bound record (VA-160)

### DIFF
--- a/attest/SKILL.md
+++ b/attest/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: attest
+description: Walk the human through the AFK attestation checklist for a `.goal-contract.yml` and write a tier-scaled attestation record. Use when the user says "attest this contract", "run attestation for VA-NNN", "I'm ready to apply afk-ready", or similar. The record gates the afk-ready label handler — no attestation, no pre-flight. Does NOT apply the label itself (deliberate, per G1).
+---
+
+# /attest
+
+Render the tier-scaled attestation checklist for the current repo's
+`.goal-contract.yml`, walk the user through it interactively, and write an
+attestation record to `.afk/attestations/<linearIssueId>.json`.
+
+The afk-ready label handler reads this record, re-computes
+`attestedContentSha` against the current YAML, and refuses to promote the
+contract (populate `metadata.approvedAt`, trigger pre-flight) if the sha
+drifted. This catches post-attestation edits without requiring a canonical
+normalization step.
+
+## When to run
+
+Immediately after:
+1. `.goal-contract.yml` exists (authored from a `.goal-contract.draft.yml`
+   produced by [`/draft-contract`](../draft-contract/SKILL.md)).
+2. All `<PLANNER_SUGGESTED:>` tokens are replaced.
+3. The scope PR is open (or about to be).
+4. The required delay window has elapsed per tier (15/30/60 min).
+
+**Before** applying the `afk-ready` label. That ordering is the whole point
+of attestation — the label should be the last thing that happens, after
+the human has consciously walked through every authority-bearing claim.
+
+## Preconditions — check before rendering anything
+
+1. **`.goal-contract.yml` exists** at repo root. If absent:
+
+   > Refusing to run. `.goal-contract.yml` not found. If you have
+   > `.goal-contract.draft.yml`, replace its `<PLANNER_SUGGESTED:>` tokens
+   > and rename first (see /draft-contract next-steps).
+
+2. **No `<PLANNER_SUGGESTED:>` tokens remain.** Grep the YAML bytes. If
+   any token is present:
+
+   > Refusing to run. `.goal-contract.yml` still contains
+   > `<PLANNER_SUGGESTED:>` token(s) at: <lines>. Replace these with real
+   > values before attesting; pre-flight will hard-reject the contract
+   > regardless (G8 gate).
+
+3. **Schema validation.** Parse the YAML and validate against
+   `afk/schemas/goal-contract.v1.json` (from the valesco-platform repo —
+   either vendored locally or looked up via the repo's `.afk/` sibling).
+   Fail loudly on AJV errors and list them.
+
+4. **Tier 1 canary-plan check.** If `metadata.tier === 1` and
+   `canaryPlan` is missing, refuse:
+
+   > Refusing to run. Tier 1 contracts require a canaryPlan block
+   > (metrics, thresholds, rollbackTrigger, windowMinutes) per governance
+   > plan G10. Author it before attesting.
+
+5. **Existing attestation check.** If
+   `.afk/attestations/<linearIssueId>.json` already exists:
+
+   > Prior attestation exists at <path>, attested <attestedAt> with
+   > `attestedContentSha` <sha>. Current YAML sha is <sha'>. {Match /
+   > Drift}. Proceeding will overwrite. OK?
+
+## Process
+
+### Step 1 — load + introspect
+
+Read `.goal-contract.yml`, parse, and compute:
+- `linearIssueId` — from `metadata.linearIssueId`
+- `tier` — from `metadata.tier`
+- `attestedContentSha` — `"sha256:" + sha256(raw file bytes)` (no
+  canonicalization; raw bytes is the contract per the keying decision)
+- `attester` — shell out to `git config user.name` and
+  `git config user.email` → `"<name> <<email>>"`
+- `timeSinceDraftMinutes` — if a prior `.goal-contract.draft.yml` exists,
+  use its mtime; else skip the field.
+
+### Step 2 — render the checklist
+
+Load [`checklist.md`](./checklist.md) and render the items that apply:
+
+- All items marked "all tiers" render always.
+- Items marked "tier 1 only" render only when `tier === 1`.
+- Items marked "tier 3 only" render only when `tier === 3`.
+- Incident-override item renders only when `metadata.incidentOverride`
+  is present.
+
+For each item, prompt the user with:
+
+> [ ] `<id>` — `<label>`
+>
+> Tick (y), skip with rationale (s), or abort (a)?
+
+Do not batch-prompt. One item at a time. A skipped item requires a
+rationale string; do not accept a blank.
+
+### Step 3 — adversarial-review posture
+
+Ask the user:
+
+> Adversarial review: has it been reviewed (r), is it pending (p), or
+> was it not run (n)?
+
+Store the answer in `adversarialReviewStatus`. This is a breadcrumb —
+the authoritative adversarial record lives in the audit store.
+
+### Step 4 — write the record
+
+Write to `.afk/attestations/<linearIssueId>.json`. Use the shape in
+[`record-reference.md`](./record-reference.md). Pretty-print with
+2-space indent; trailing newline.
+
+If `.afk/attestations/` does not exist, create it. The skill is
+allowed to create `.afk/`-nested paths under attestations — that
+directory is not on the hard floor.
+
+### Step 5 — verify against schema
+
+Validate the written JSON against
+`afk/schemas/attestation-record.v1.json`. On failure, delete the file
+and report the error. Never leave a malformed record on disk.
+
+### Step 6 — print next steps
+
+```
+Attestation written: .afk/attestations/<linearIssueId>.json
+  tier: <N>
+  ticked: <count> / <total>
+  skipped: <count> (rationales required)
+  attestedContentSha: <first 12 hex chars>…
+  adversarialReviewStatus: <reviewed | pending | not-run>
+
+Next:
+  1. Commit the attestation record to the scope PR branch.
+  2. Confirm the delay window has elapsed:
+       • Tier 1 default: 15 min (30 min sensitive; 60 min meta-contract)
+       • Tier 2 default: 5 min (15 min sensitive; 30 min meta-contract)
+       • Tier 3 default: 0 min (5 min sensitive; 15 min meta-contract)
+  3. Apply the `afk-ready` label.
+  4. The label handler will re-verify `attestedContentSha` matches the
+     current YAML and reject the promotion on drift.
+
+Any edit to `.goal-contract.yml` after this moment invalidates the
+attestation — re-run `/attest` after every authority-bearing change.
+```
+
+## Self-validation before returning
+
+- [ ] `.afk/attestations/<linearIssueId>.json` exists and parses as JSON.
+- [ ] Record validates against `attestation-record.v1.json`.
+- [ ] `attestedContentSha` matches `sha256:` + sha256 of current
+      `.goal-contract.yml` bytes.
+- [ ] Every `state: "skipped"` item has a non-empty `rationale`.
+- [ ] Every `state: "ticked"` item has no `rationale` field.
+
+If any check fails, delete the record and report the specific failure.
+
+## Non-goals
+
+- **No label application.** G1 mandates the human applies `afk-ready`
+  by hand, consciously, after attestation. Automating this collapses
+  the separation-of-concerns the attestation exists to enforce.
+- **No pre-flight invocation.** Pipeline runs on its own triggers.
+- **No adversarial-review execution.** The skill records posture only;
+  running adversarial review is a separate pipeline concern.
+- **No override-rate tracking.** Circuit-breaker + weekly cap live in
+  pipeline per G1, not here.
+- **No canonical-normalization.** Raw-bytes sha is authoritative for
+  now; canonical form is a separate future ticket.
+
+## References
+
+- `valesco-platform/afk/schemas/attestation-record.v1.json` (authoritative
+  record shape)
+- `valesco-platform/afk/schemas/goal-contract.v1.json` (contract
+  pre-validation)
+- `valesco-platform/docs/afk/governance-plan.md` §G1 (checklist rationale)
+- `valesco-platform/docs/afk/governance-plan.md` §7 (authority chain —
+  hash binding)
+- [`../draft-contract/SKILL.md`](../draft-contract/SKILL.md) (upstream
+  skill)
+- [`./checklist.md`](./checklist.md) (per-tier checklist items)
+- [`./record-reference.md`](./record-reference.md) (record shape worked
+  example)

--- a/attest/checklist.md
+++ b/attest/checklist.md
@@ -1,0 +1,142 @@
+# Attestation checklist
+
+Reference for `/attest`. One item per bullet. Each item has:
+
+- **id** — stable kebab-case identifier (recorded in the attestation
+  record; never rename, only add/deprecate).
+- **label** — human-readable prompt rendered to the attester (stored
+  verbatim in the record so future copy-edits don't rewrite history).
+- **applies** — which tiers the item renders for.
+
+Rendering order is the order below. The skill MAY skip rendering an
+item whose `applies` clause excludes the current tier / condition, but
+MUST NOT reorder within what it does render.
+
+---
+
+## All tiers
+
+### `intent-matches-linear`
+
+**Applies:** all tiers.
+
+> I have re-read the referenced Linear issue within the last 15
+> minutes. The contract's `intent.description`, `successCriteria`, and
+> `nonGoals` still reflect the issue's current wording — no silent
+> drift between Linear and the YAML.
+
+### `paths-are-minimal`
+
+**Applies:** all tiers.
+
+> `scope.requiredPaths` and `scope.writePaths` are the minimum set
+> required to satisfy the contract. I have not included a broad glob
+> (e.g., `src/**`) when a narrower one (e.g., `src/components/foo/**`)
+> would work.
+
+### `no-hard-floor-in-writepaths`
+
+**Applies:** all tiers.
+
+> No hard-floor path appears in `scope.writePaths`. Hard-floor paths
+> are: `.github/workflows/**`, `.github/actions/**`,
+> `.github/CODEOWNERS`, `.github/dependabot.yml`, `vercel.json`,
+> `.vercelignore`, `.goal-contract.yml`, `.afk/**`,
+> `afk/policies/**`, `docs/prd/**`, `.env*` (except `.env.example`).
+>
+> Escalated-floor paths (`supabase/migrations/**`,
+> `supabase/config.toml`, `package.json`, `pnpm-lock.yaml`,
+> `tsconfig*.json`, `next.config.*`, `middleware.ts`,
+> `src/middleware.ts`) may appear but require a meta-contract — skip
+> this item with a rationale if that's the case.
+
+### `cost-estimate-acknowledged`
+
+**Applies:** all tiers.
+
+> I have reviewed the pre-flight cost estimate (or acknowledged that
+> pre-flight has not yet been run and the tier's default per-contract
+> budget will apply).
+
+### `time-delay-elapsed`
+
+**Applies:** all tiers.
+
+> At least the required delay has elapsed between the contract's
+> initial draft write and now:
+>
+> | tier | default | sensitive paths | meta-contract |
+> |---|---|---|---|
+> | 1 | 15 min | 30 min | 60 min |
+> | 2 | 5 min | 15 min | 30 min |
+> | 3 | 0 min | 5 min | 15 min |
+>
+> Sensitive paths: auth, `supabase/migrations/**`, billing, any path
+> flagged "production-critical" in repo metadata.
+
+### `adversarial-review-considered`
+
+**Applies:** all tiers.
+
+> I have considered the adversarial review outcome (or noted it as
+> pending / not-run, captured separately in
+> `adversarialReviewStatus`). No `escalate_human` or `fail` verdict
+> is being ignored.
+
+---
+
+## Tier 1 only
+
+### `customer-identifier-correct`
+
+**Applies:** `metadata.tier === 1`.
+
+> `metadata.customer` matches the customer this work is actually for.
+> A wrong customer field wrecks per-customer cost attribution and
+> retention policy.
+
+### `canary-plan-sensible`
+
+**Applies:** `metadata.tier === 1`.
+
+> `canaryPlan.metrics`, `canaryPlan.thresholds`, and
+> `canaryPlan.rollbackTrigger` are concrete and executable. Thresholds
+> are calibrated to the actual deployment's normal-range baseline,
+> not round-number guesses. `rollbackTrigger` is a real command or
+> Vercel action, not a TBD placeholder.
+
+---
+
+## Tier 3 only
+
+### `tier-3-not-expired`
+
+**Applies:** `metadata.tier === 3`.
+
+> `.afk/config.yml` has a `tier_expires` date and that date has not
+> yet passed. Tier 3 projects auto-fail pre-flight after expiration
+> until renewed by a Tier-2+ ceremony.
+
+---
+
+## Conditional on contract content
+
+### `incident-override-rationale`
+
+**Applies:** `metadata.incidentOverride` present.
+
+> `metadata.incidentOverride.linearIssueRef` points at a real
+> incident issue, and `metadata.incidentOverride.rationale` is a
+> genuine description of the urgency — not a workaround for impatience
+> with the normal delay window. I understand this counts as an
+> `urgent_business_need` override against the override budget.
+
+---
+
+## Deprecated / removed items
+
+When an item is retired, it moves here with a removal date and the
+ticket that retired it. Never delete the id history — past records
+still reference the old ids.
+
+_(none yet)_

--- a/attest/record-reference.md
+++ b/attest/record-reference.md
@@ -1,0 +1,130 @@
+# Attestation record — worked example
+
+Authoritative shape lives in
+`valesco-platform/afk/schemas/attestation-record.v1.json`. This file
+is a human-readable reference showing two worked examples (all-ticked
+and mixed ticked/skipped). The schema is the source of truth; if this
+file drifts, the schema wins.
+
+## Shape
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "linearIssueId": "<TEAM-NNN>",
+  "attestedContentSha": "sha256:<64 hex chars>",
+  "tier": 1 | 2 | 3,
+  "attestedAt": "<ISO 8601 datetime>",
+  "attester": "<git user.name <user.email>>",
+  "adversarialReviewStatus": "reviewed" | "pending" | "not-run",
+  "timeSinceDraftMinutes": <non-negative integer>,
+  "items": [
+    {
+      "id": "<kebab-case>",
+      "label": "<verbatim prompt as rendered>",
+      "state": "ticked" | "skipped",
+      "rationale": "<required when skipped; forbidden when ticked>"
+    }
+  ]
+}
+```
+
+Keys:
+
+- `linearIssueId` is the record's key on disk: file lives at
+  `.afk/attestations/<linearIssueId>.json`. One record per Linear
+  issue at a time; re-running `/attest` overwrites.
+- `attestedContentSha` is the raw SHA-256 of the `.goal-contract.yml`
+  file bytes at attestation time. The afk-ready label handler
+  re-computes this sha against the current YAML; drift rejects the
+  promotion.
+- `adversarialReviewStatus` and `timeSinceDraftMinutes` are optional.
+
+## Example 1 — Tier 3, all items ticked
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "linearIssueId": "VA-160",
+  "attestedContentSha": "sha256:7d793037a0760186574b0282f2f435e7b8a9b26edb6c1b0a8d42fd9c8c3e5f01",
+  "tier": 3,
+  "attestedAt": "2026-04-22T01:12:00Z",
+  "attester": "Jason Kennemer <jason@valescoagency.com>",
+  "adversarialReviewStatus": "reviewed",
+  "timeSinceDraftMinutes": 20,
+  "items": [
+    {
+      "id": "intent-matches-linear",
+      "label": "I have re-read the referenced Linear issue within the last 15 minutes. The contract's intent.description, successCriteria, and nonGoals still reflect the issue's current wording — no silent drift between Linear and the YAML.",
+      "state": "ticked"
+    },
+    {
+      "id": "paths-are-minimal",
+      "label": "scope.requiredPaths and scope.writePaths are the minimum set required to satisfy the contract. I have not included a broad glob (e.g., src/**) when a narrower one would work.",
+      "state": "ticked"
+    },
+    {
+      "id": "no-hard-floor-in-writepaths",
+      "label": "No hard-floor path appears in scope.writePaths. ...",
+      "state": "ticked"
+    },
+    {
+      "id": "cost-estimate-acknowledged",
+      "label": "I have reviewed the pre-flight cost estimate (or acknowledged that pre-flight has not yet been run and the tier's default per-contract budget will apply).",
+      "state": "ticked"
+    },
+    {
+      "id": "time-delay-elapsed",
+      "label": "At least the required delay has elapsed between the contract's initial draft write and now. ...",
+      "state": "ticked"
+    },
+    {
+      "id": "adversarial-review-considered",
+      "label": "I have considered the adversarial review outcome. ...",
+      "state": "ticked"
+    },
+    {
+      "id": "tier-3-not-expired",
+      "label": ".afk/config.yml has a tier_expires date and that date has not yet passed. ...",
+      "state": "ticked"
+    }
+  ]
+}
+```
+
+## Example 2 — Tier 1, incident override, time-delay skipped
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "linearIssueId": "VA-242",
+  "attestedContentSha": "sha256:c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646",
+  "tier": 1,
+  "attestedAt": "2026-04-22T03:04:00Z",
+  "attester": "Jason Kennemer <jason@valescoagency.com>",
+  "adversarialReviewStatus": "reviewed",
+  "timeSinceDraftMinutes": 4,
+  "items": [
+    { "id": "intent-matches-linear", "label": "...", "state": "ticked" },
+    { "id": "paths-are-minimal", "label": "...", "state": "ticked" },
+    { "id": "no-hard-floor-in-writepaths", "label": "...", "state": "ticked" },
+    { "id": "cost-estimate-acknowledged", "label": "...", "state": "ticked" },
+    {
+      "id": "time-delay-elapsed",
+      "label": "At least the required delay has elapsed ...",
+      "state": "skipped",
+      "rationale": "Incident override VA-241 — prod auth regression; 15-min sensitive-path delay waived per G1 incidentOverride rule. Logged as urgent_business_need override."
+    },
+    { "id": "adversarial-review-considered", "label": "...", "state": "ticked" },
+    { "id": "customer-identifier-correct", "label": "...", "state": "ticked" },
+    { "id": "canary-plan-sensible", "label": "...", "state": "ticked" },
+    { "id": "incident-override-rationale", "label": "...", "state": "ticked" }
+  ]
+}
+```
+
+## Validation
+
+The skill writes the record then validates it against
+`attestation-record.v1.json` before returning. On AJV failure, the
+record is deleted, not left on disk. See `SKILL.md` step 5.

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -17,19 +17,25 @@ Each entry:
 
 ## Open skill gaps
 
-### `/attest`
+### `/attest` — **in progress**
 
 - **Purpose**: Render the attestation checklist from a `.goal-contract.yml`
   and walk the user through tick-through (time-delay acknowledgement,
   protected-path confirmation, cost-estimate acknowledgement, tier-specific
   extras like canary plan on Tier 1). Emits an attestation record that the
-  pre-flight pipeline reads.
-- **Trigger-to-author**: Before the first real contract hits `afk-ready`.
-  Checklist-as-skill is preferable to checklist-in-PR-template because the
-  skill can validate the contract as it renders.
+  afk-ready label handler reads to decide whether to promote the contract.
+- **Status**: Skill + schema authored 2026-04-22. Schema ships via
+  valesco-platform PR [#31](https://github.com/ValescoAgency/valesco-platform/pull/31)
+  (`afk/schemas/attestation-record.v1.json` + 26 AJV tests). Skill files
+  (`attest/SKILL.md`, `checklist.md`, `record-reference.md`) on this PR.
+- **Keying decision**: records keyed by `linearIssueId`, not by canonical
+  `contractHash`. `attestedContentSha` (raw SHA-256 of
+  `.goal-contract.yml` bytes) carries integrity; the label handler
+  re-computes and rejects on drift. Canonical normalization is a
+  separate future concern.
 - **Classification**: skill (the checklist is advisory; the _record_ it
   produces is consumed by pipeline, which is authority).
-- **Tracking**: none yet — file when authoring begins.
+- **Tracking**: [VA-160](https://linear.app/valescoagency/issue/VA-160).
 
 ### `/preflight-report`
 


### PR DESCRIPTION
## Summary

- Ships the `/attest` skill: tier-scaled attestation checklist walk → record written to `.afk/attestations/<linearIssueId>.json`.
- Three new files at `attest/` (per Claude Code plugin convention — one dir per skill at repo root):
  - `SKILL.md` — frontmatter, auto-invoke trigger phrases, 6-step process, self-validation, non-goals
  - `checklist.md` — per-tier item library with stable ids, never-rename policy
  - `record-reference.md` — two worked record examples (all-ticked Tier 3, mixed Tier 1 with incident override)
- `docs/gaps.md` — `/attest` entry moves to **in progress** with tracking to VA-160 and a note on the keying decision.

Record keyed by `linearIssueId`; integrity via `attestedContentSha` (raw SHA-256 of `.goal-contract.yml` bytes). The afk-ready label handler re-computes and rejects on drift. Canonical normalization is explicitly deferred — separate future ticket.

Companion schema PR: https://github.com/ValescoAgency/valesco-platform/pull/31

Part of VA-160.

## Test plan

- [ ] Dry-run the skill on a real repo with a valid `.goal-contract.yml` — verify checklist renders per tier, skipped items prompt for rationale, record validates against the v1 schema.
- [ ] Dry-run on a repo with `<PLANNER_SUGGESTED:>` tokens remaining — verify hard refusal.
- [ ] Dry-run on a Tier 1 contract with missing `canaryPlan` — verify hard refusal.
- [x] Companion schema PR ships 26 AJV tests covering record shape, pattern constraints, skipped/ticked rationale conditional, required fields, tier + adversarialReviewStatus enums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)