### PR TITLE
feat(skills): add /diagnose, /feedback-loop, /brief-to-contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "valesco",
-  "version": "0.1.0",
-  "description": "Valesco-authored Claude Code skills for the AFK autonomous-coding governance pipeline. Bundles user-invoked, advisory skills only — pipeline code (validators, pre-flight, audit) lives in valesco-platform per the skills-vs-pipeline rule.",
+  "version": "0.2.0",
+  "description": "Valesco-authored Claude Code skills for harness engineering and agent orchestration around the AFK autonomous-coding governance pipeline. Bundles the orchestration spine (/brief-to-contract), harness skills (/diagnose, /feedback-loop), Linear funnel (/linear-triage), goal-contract drafting (/draft-contract), and tier-scaled attestation (/attest). User-invoked, advisory skills only — pipeline code (validators, pre-flight, audit, label handler) lives in valesco-platform per the skills-vs-pipeline rule.",
   "author": {
     "name": "Valesco Agency",
     "email": "jason@valescoagency.com",
@@ -15,6 +15,11 @@
     "afk",
     "governance",
     "linear",
-    "goal-contract"
+    "goal-contract",
+    "harness-engineering",
+    "agent-orchestration",
+    "diagnose",
+    "feedback-loop",
+    "brief-to-contract"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,37 +1,65 @@
-# ValescoAgency/skills
+# ValescoAgency/flightplan
 
-Claude Code skills authored by or curated for [Valesco Agency](https://valescoagency.com).
+Claude Code skills authored by or curated for [Valesco Agency](https://valescoagency.com)
+to develop software via **harness engineering and agent orchestration**.
 
 Primary consumer: the AFK (autonomous) coding governance pipeline at
 [`ValescoAgency/valesco-platform`](https://github.com/ValescoAgency/valesco-platform).
 
 ## Contents
 
-- [`docs/starter-set.md`](docs/starter-set.md) — the specific skills adopted for
-  Valesco work, with rationale.
-- [`docs/gaps.md`](docs/gaps.md) — skills known to be missing, registered as they
-  bite.
-- `<skill-name>/SKILL.md` — authored Valesco skills live at the repo root,
-  one directory per skill (Claude Code plugin convention). Empty at repo
-  birth; populated as gaps are closed.
+- [`docs/workflow.md`](docs/workflow.md) — end-to-end harness +
+  orchestration map, repo conventions (`CONTEXT.md`, `docs/adr/`,
+  `.afk/config.yml`), HITL fork, skills-vs-pipeline boundary.
+- [`docs/starter-set.md`](docs/starter-set.md) — adopted skills (Valesco
+  + Matt Pocock + Addy Osmani), with rationale.
+- [`docs/gaps.md`](docs/gaps.md) — open gaps, pipeline cross-references,
+  closed gaps with ship dates.
+- `<skill-name>/SKILL.md` — Valesco-authored skills, one directory per
+  skill (Claude Code plugin convention).
+
+## Skills shipped in this plugin
+
+| Skill | Purpose |
+|---|---|
+| [`/linear-triage`](linear-triage/SKILL.md) | Funnel Linear issues toward `ready-for-agent` with an Agent Brief comment. AFK-eligibility-aware. |
+| [`/diagnose`](diagnose/SKILL.md) | Six-phase debugging discipline; Phase 1 builds the verifier the goal-contract will use. |
+| [`/feedback-loop`](feedback-loop/SKILL.md) | The 10-pattern catalog for constructing deterministic agent-runnable signals. |
+| [`/draft-contract`](draft-contract/SKILL.md) | Lift a Linear issue into `.goal-contract.draft.yml` with `<PLANNER_SUGGESTED:>` tokens (§G8 gate). |
+| [`/attest`](attest/SKILL.md) | Tier-scaled attestation checklist; writes `.afk/attestations/<id>.json`. |
+| [`/brief-to-contract`](brief-to-contract/SKILL.md) | Orchestration spine — drives a Linear issue from triage through to attested contract with resume detection + HITL exits. |
+
+These compose with Matt Pocock's
+[engineering skills](https://github.com/mattpocock/skills/tree/main/skills/engineering)
+(`/grill-with-docs`, `/to-prd`, `/to-issues`,
+`/improve-codebase-architecture`, `/zoom-out`, `/tdd`) per the workflow
+in [`docs/workflow.md`](docs/workflow.md).
 
 ## Skills-vs-pipeline rule
 
 Load-bearing constraint on what belongs here:
 
-- **Pipeline code** (lives in `valesco-platform/afk/`): capabilities touching
-  hash-bound authority, audit records, tier gates, or requiring deterministic +
-  replayable behavior. Validator runs, pre-flight checks, authority binding.
-- **Skills** (live here): capabilities that are advisory, exploratory, or
-  user-invoked. PRD drafting, domain modeling, triage, adversarial review
-  passes, attestation walkthroughs.
+- **Pipeline code** (lives in `valesco-platform/afk/`): capabilities
+  touching hash-bound authority, audit records, tier gates, or requiring
+  deterministic + replayable behavior. Validator runs, pre-flight checks,
+  authority binding, label handler.
+- **Skills** (live here): capabilities that are advisory, exploratory,
+  or user-invoked. PRD drafting, domain modeling, triage, diagnosis,
+  attestation walkthroughs, contract-drafting, orchestration spine.
 
-If a proposed skill would violate the boundary, it becomes a pipeline ticket,
-not a skill.
+If a proposed skill would violate the boundary, it becomes a pipeline
+ticket, not a skill. See [`docs/gaps.md`](docs/gaps.md) for the
+cross-reference list of pipeline items registered there only so skill
+work doesn't accidentally pick them up.
 
 ## Related
 
-- [valesco-platform](https://github.com/ValescoAgency/valesco-platform) — AFK
-  governance + platform code
-- [docs/sdlc/workflow.md](https://github.com/ValescoAgency/valesco-platform/blob/main/docs/sdlc/workflow.md) — Valesco SDLC including §8 AFK governance
-- [docs/afk/governance-plan.md](https://github.com/ValescoAgency/valesco-platform/blob/main/docs/afk/governance-plan.md) — boundary constraints any adopted skill must respect
+- [`valesco-platform`](https://github.com/ValescoAgency/valesco-platform)
+  — AFK governance + platform code
+- [`docs/sdlc/workflow.md`](https://github.com/ValescoAgency/valesco-platform/blob/main/docs/sdlc/workflow.md)
+  — Valesco SDLC including §8 AFK governance
+- [`docs/afk/governance-plan.md`](https://github.com/ValescoAgency/valesco-platform/blob/main/docs/afk/governance-plan.md)
+  — boundary constraints any adopted skill must respect
+- [Matt Pocock's skills](https://github.com/mattpocock/skills) —
+  upstream for `/grill-with-docs`, `/to-prd`, `/to-issues`,
+  `/improve-codebase-architecture`, `/zoom-out`, `/tdd`

--- a/brief-to-contract/SKILL.md
+++ b/brief-to-contract/SKILL.md
@@ -1,0 +1,410 @@
+---
+name: brief-to-contract
+description: Orchestrate a Linear issue through the full Valesco AFK chain — from triage to attested goal-contract — by sequentially invoking the right per-stage skills (`/linear-triage`, `/diagnose`, `/grill-with-docs`, `/draft-contract`, `/attest`). Use when the user says "take VA-NNN through to attested contract", "run brief-to-contract for VA-NNN", "I want to AFK this issue", "walk this through the pipeline", "what's the next step on VA-NNN", or asks to drive a Linear ticket end-to-end toward an AFK run. This skill IS the orchestration spine — it does not replace `/linear-triage` (one-shot triage), `/draft-contract` (one-shot draft), or `/attest` (one-shot attestation); it composes them with the right gates, resume detection, and HITL exits. Reach for it whenever you'd otherwise be manually stitching those skills together to advance one issue.
+---
+
+# /brief-to-contract
+
+Walk a Linear issue from inbound state all the way to an attested
+`.goal-contract.yml` that is ready for the human to apply `afk-ready` to.
+The skill is a **stitcher** — it sequences calls to the per-stage skills,
+detects which stage is already done, enforces the gates between them, and
+exits cleanly when an issue turns out to be HITL.
+
+This skill writes **no authority-bearing artefacts of its own**. It posts
+status comments to Linear (with the AI disclaimer), and it tells *other*
+skills to write things. The afk-ready label is never applied here — that
+is deliberate human work per governance plan §G1.
+
+## When to run
+
+When you have a Linear issue (or want to find one) and intend to drive it
+toward an AFK run. The skill picks the right starting stage based on the
+issue's current state — you don't need to know whether triage has
+happened, or a draft exists, or attestation is in place. It detects all of
+that.
+
+## When NOT to run
+
+- The issue is already attested and `afk-ready` is applied — pipeline owns
+  it now; this skill is read-only at that point and will just print the
+  current status.
+- The user wants to do a single stage by hand (just triage, just draft,
+  just attest) — invoke the per-stage skill directly. This one is for the
+  end-to-end walk.
+- The repo is a control plane (`afkEligible: false`) — the skill refuses
+  in Stage 0 and routes the user to `/linear-triage` for `ready-for-human`
+  instead.
+
+## Authority boundary — what this skill never does
+
+| Action | Why this skill doesn't do it |
+|---|---|
+| Apply the `afk-ready` label | §G1 — the human applies it consciously, after the delay window, as the last act before pre-flight. |
+| Run pre-flight | §G1 — pre-flight triggers on the label, not on this skill. |
+| Auto-fill `<PLANNER_SUGGESTED:>` tokens | §G8 — every authority field is human-authored. |
+| Rename `.goal-contract.draft.yml` → `.goal-contract.yml` | §G8 — the rename is the human's act of taking ownership of the contract content. |
+| Modify `.afk/attestations/*.json` directly | The `/attest` skill owns that path. This one calls `/attest`; it doesn't write the record. |
+| Open the scope PR | Out of scope per existing per-skill non-goals. |
+| Skip stages on user request without confirmation | The skill confirms the resume point but won't bypass a structural gate (e.g., it won't draft a contract for an issue that hasn't been triaged). |
+
+## Stage 0 — Pre-flight
+
+Read `.afk/config.yml` at the working repo root before doing anything else.
+
+| Field | Effect |
+|---|---|
+| `afkEligible: false` | **Refuse and route.** Print: "This repo is a control plane (afkEligible:false). AFK contracts cannot run against it (§14.3). Hand the issue to `/linear-triage` and drive it to `ready-for-human` instead." Then stop. |
+| `afkEligible: true` + `projectTier: 1` | Note for later — the skill will recommend canaryPlan when entering Stage 4. |
+| `afkEligible: true` + `projectTier: 2` or `3` | Standard chain applies. |
+| missing | Surface to the maintainer. The skill cannot orchestrate without knowing tier and eligibility. |
+
+Also confirm the working directory is a git repo with `.afk/` present —
+otherwise this isn't an AFK-aware repo and the skill has nothing to
+orchestrate.
+
+## Resume detection — pick the right entry stage
+
+Before announcing a stage, the skill walks the artefact tree and decides
+the entry point. Detection rules in detail:
+[`state-machine.md`](./state-machine.md). Summary table:
+
+| Existing artefact | Entry stage | Skill announces |
+|---|---|---|
+| `.afk/attestations/<linearIssueId>.json` exists, sha matches current `.goal-contract.yml` | Stage 8 | "Already attested. Printing hand-off." |
+| `.goal-contract.yml` exists, no `<PLANNER_SUGGESTED:>` tokens, no attestation record (or sha drift) | Stage 7 | "Contract authored; entering attestation." |
+| `.goal-contract.yml` exists, but `<PLANNER_SUGGESTED:>` tokens remain | Refuse to advance | "Contract has unreplaced tokens. Replace them, then I'll run /attest." |
+| `.goal-contract.draft.yml` exists, no `.goal-contract.yml` | Stage 5 | "Draft exists; awaiting token replacement + rename." |
+| Linear issue is `Todo` + `ready-for-agent` + has Agent Brief comment | Stage 2 (or 4 if Bug already has captured reproducer / not a Bug) | "Brief in place; entering diagnosis check." |
+| Linear issue is `Triage` or `needs-info` | Stage 1 | "Issue not yet brief-ready; entering triage." |
+| Linear issue is `In Progress` / `In Review` / `Reviewed` | **Read-only** | "Issue is in active work; this skill is read-only on those statuses." |
+
+Always **announce** the detected resume point and ask the user to confirm
+or override before proceeding. A misdetected resume point can skip a gate
+the user wanted to revisit.
+
+## Stage 1 — Triage gate
+
+If the issue isn't yet at `status=Todo` + `label=ready-for-agent` + has an
+Agent Brief comment, invoke [`/linear-triage`](../linear-triage/SKILL.md)
+and let it do its work.
+
+After triage returns, branch on the outcome:
+
+| Triage outcome | Action |
+|---|---|
+| `ready-for-agent` | Continue to Stage 2. |
+| `ready-for-human` | **HITL exit.** Print the human-brief that triage authored, plus a one-line "this issue is being handed to you, not to AFK — work it manually." Stop. |
+| `needs-info` | **Pause exit.** Print "Triage posted Triage Notes; the reporter needs to answer before this can advance. Re-run me when they reply." Stop. |
+| `Backlog` / `Canceled` / `Duplicate` | **Done exit.** Print the resolution and stop. The chain doesn't apply. |
+
+Triage is also where the **HITL fork** is most likely to fire. The skill
+never tries to coerce a `ready-for-human` issue back toward AFK.
+
+## Stage 2 — Diagnosis gate (Bugs only)
+
+For category `Bug`, check whether the Agent Brief contains a captured
+reproducer:
+
+- A linked Phase 1 feedback loop (script, test path, harness file)
+- A regression test reference under `intent.successCriteria` shape
+- An explicit "reproduced via X" line in the brief
+
+If any of those is missing, invoke [`/diagnose`](../diagnose/SKILL.md). The
+diagnose run will:
+
+1. Build the feedback loop (`/feedback-loop` patterns 1–10).
+2. Reproduce the bug.
+3. Hypothesise + instrument + fix-or-document.
+4. Output a regression test and a verifier-ready loop command.
+
+After `/diagnose` returns, **fold its outputs back into the Linear issue**:
+
+- Append a comment (with AI disclaimer) summarizing: feedback-loop
+  command, regression test path, the post-mortem one-liner.
+- Update the Agent Brief comment in place if it lacks the reproducer
+  reference. (The brief is what `/draft-contract` reads — keep it
+  current.)
+
+If `/diagnose` exits at Phase 1 because no reproducer can be built, this
+is a **HITL-back-to-triage exit**. Drop back to Stage 1 with a
+`needs-info` recommendation listing the specific blockers diagnose found
+(reproducer access / captured artefact / production instrumentation).
+
+For categories `Feature` / `Improvement`, skip this stage — there's no bug
+to reproduce.
+
+## Stage 3 — Domain alignment gate (optional)
+
+Read [`CONTEXT.md`](../docs/workflow.md#contextmd--ubiquitous-language)
+and skim [`docs/adr/`](../docs/workflow.md#adrs). Then read the Agent
+Brief.
+
+Invoke [`/grill-with-docs`](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md)
+**only when** at least one of these holds:
+
+- The brief uses a domain term that isn't in `CONTEXT.md` *and* could
+  be ambiguous (e.g. "account" without a Customer/User distinction).
+- The brief proposes an architectural shape that contradicts an existing
+  ADR.
+- Tier-1 brief whose `intent.description` is fewer than 200 chars — the
+  pipeline will likely accept it, but the AFK runner will produce
+  generic code without sharper context.
+
+Otherwise, **skip this stage**. The grill is genuine work — don't impose
+it on issues that don't need it.
+
+After grill returns, treat any new ADRs or `CONTEXT.md` updates as
+follow-on commits the user should make on the scope PR branch (when
+they open it in Stage 8).
+
+## Stage 4 — Draft
+
+Before invoking, do **tier escalation detection**:
+
+| Signal | Recommend |
+|---|---|
+| Linear issue has a `customer` field set | Tier 1 |
+| Likely `writePaths` touch `**/auth/**`, `**/billing/**`, `**/migrations/**`, `supabase/migrations/**`, `src/**/payment*` | Tier 1 |
+| Linear issue is in a Tier-1 project per `.afk/config.yml` | Tier 1 |
+| None of the above | Tier 3 default (matches `/draft-contract`'s posture) |
+
+Tell the user the recommendation and the reason, then invoke
+[`/draft-contract`](../draft-contract/SKILL.md) with the Linear issue ID.
+The draft skill writes `.goal-contract.draft.yml` with
+`<PLANNER_SUGGESTED:>` tokens for human-authored fields; for Tier 1, the
+`canaryPlan` block is one of those tokens.
+
+After `/draft-contract` returns, post a Linear comment (with AI
+disclaimer) noting that the draft is in place and what the user needs to
+do next (token replacement). Do not include the contract contents in the
+comment — that's noise, and it tempts future readers to edit the contract
+in Linear instead of in the file.
+
+## Stage 5 — Token replacement (HITL by design)
+
+Print the list of every `<PLANNER_SUGGESTED:>` token currently in the
+draft, with file:line locations and the descriptive token text. Then **wait**.
+
+The user replaces tokens by hand. This is a §G8 gate — auto-fill is
+explicitly forbidden because tokens mark fields where authority must be
+human-derived (the agent doesn't know which globs are right; it can only
+suggest).
+
+A reasonable presentation:
+
+```
+.goal-contract.draft.yml has 6 unreplaced <PLANNER_SUGGESTED:> tokens:
+
+  L24  writePaths:
+       - "<PLANNER_SUGGESTED: propose minimal globs under src/app/api/...>"
+  L31  budget.timeMinutes
+       "<PLANNER_SUGGESTED: 15-30 for routine, 60+ for migration-heavy>"
+  L48  canaryPlan
+       "<PLANNER_SUGGESTED: required for Tier 1 — name metrics, thresholds...>"
+  ...
+
+Replace each token with a real value, then say "tokens replaced" or
+re-run me. I will not auto-fill.
+```
+
+When the user says they're done (or re-invokes the skill), grep the file
+for the token marker. If any remain, list them and stop. If none remain,
+advance to Stage 6.
+
+## Stage 6 — Rename
+
+Prompt the user to rename `.goal-contract.draft.yml` →
+`.goal-contract.yml`. **Do not perform the rename.** The act is the human
+taking ownership of the contract content per §G8 — the skill renaming it
+collapses the meaningfulness of that act.
+
+```
+Tokens replaced. Rename the file when ready:
+
+  mv .goal-contract.draft.yml .goal-contract.yml
+
+When the rename is in place, say "renamed" or re-run me. I will check the
+file exists at the new path and advance to attestation.
+```
+
+When the user confirms, verify `.goal-contract.yml` exists and
+`.goal-contract.draft.yml` is gone. If both exist, refuse — having two
+contract files at once is a dangerous state. If only the draft remains,
+prompt again. Only when exactly `.goal-contract.yml` exists at the root,
+proceed.
+
+## Stage 7 — Attest
+
+Invoke [`/attest`](../attest/SKILL.md). The attestation skill walks the
+human through the tier-scaled checklist and writes
+`.afk/attestations/<linearIssueId>.json`.
+
+This skill **blocks** until the attestation record exists with
+`attestedContentSha` matching the current YAML. If `/attest` is aborted
+or the user skips it, the chain stops here — there is no Stage 8 without
+a fresh attestation.
+
+After `/attest` returns successfully:
+
+- Verify `.afk/attestations/<linearIssueId>.json` parses, validates, and
+  matches the current YAML's sha.
+- If sha drift is detected later (the user edited the contract after
+  attestation), refuse Stage 8 and tell them to re-attest.
+
+Post a Linear comment (with AI disclaimer) confirming attestation is in
+place — but **never** the attestation record contents.
+
+## Stage 8 — Hand-off
+
+Print the final next-steps block:
+
+```
+Contract attested for <TEAM-NNN> ("<issue title>"):
+  tier:        <N>
+  attestedContentSha: <first 12 hex chars>...
+  attestedAt:  <ISO timestamp>
+  attester:    <name <email>>
+
+Next, by hand:
+  1. Open the scope PR with "Fixes <TEAM-NNN>" in the body.
+     Commit the attestation record to the scope PR branch.
+  2. Wait the tier-appropriate delay window:
+       Tier 1: 15 min (30 min sensitive; 60 min meta-contract)
+       Tier 2: 5 min  (15 min sensitive; 30 min meta-contract)
+       Tier 3: 0 min  (5 min sensitive;  15 min meta-contract)
+  3. Apply the `afk-ready` label.
+     The label handler will re-verify attestedContentSha against the
+     current YAML and refuse promotion on drift.
+  4. Pre-flight runs. AFK takes over.
+
+Any edit to .goal-contract.yml after this moment invalidates the
+attestation — re-run /attest first, then re-apply the label.
+
+This skill is done. The pipeline owns the issue from here.
+```
+
+Stop after printing. Don't apply the label. Don't open the PR. Don't
+trigger pre-flight.
+
+## HITL fork — exit conditions across stages
+
+The HITL fork can fire at any stage. When it does, exit cleanly with
+whatever progress was captured. Never coerce a HITL issue toward AFK.
+
+| Stage | HITL trigger | Exit message |
+|---|---|---|
+| 0 | `afkEligible: false` | "Control plane — route to `/linear-triage` for `ready-for-human`." |
+| 1 | Triage decides `ready-for-human` | Show the human-brief; stop. |
+| 1 | Triage decides `needs-info` | Show the missing facts; stop. |
+| 2 | `/diagnose` cannot build a reproducer | Drop back to Stage 1 with a specific `needs-info` recommendation. |
+| 3 | `/grill-with-docs` reveals the user has no clear answer (e.g. genuine open architectural question) | Pause — the question is real engineering work, not contract drafting. |
+| 4 | Tier-1 escalation declined and the issue still touches sensitive globs | Stop and ask whether to retag the issue or accept Tier 1. |
+| 5 | Tokens reveal the user genuinely doesn't know the right values | Surface the unknowns, drop back to Stage 3 (grill). |
+| 7 | Attestation aborted | Stop — without attestation there is no afk-ready. |
+
+## Tier escalation logic (detail)
+
+Tier 1 contracts require canaryPlan. The skill's job is to **detect early**
+and recommend Tier 1 *before* `/draft-contract` runs, so the draft is
+authored with Tier-1 defaults rather than retrofitted.
+
+Detection inputs:
+
+1. **`.afk/config.yml`** — if `projectTier: 1`, all issues default to Tier 1.
+2. **Linear issue body** — does it mention a customer name? Production
+   incident ID? "client-critical" / "billing" / "auth flow" language?
+3. **Inferred `writePaths`** — read the brief, plus any architectural
+   anchors. If the writes likely touch sensitive globs, escalate.
+4. **`/diagnose` output** — if the regression test sits in
+   `**/auth/**` or similar, escalate.
+
+Surface the recommendation as one paragraph before Stage 4 begins:
+
+```
+Recommending Tier 1 for this contract:
+  - Issue customer field is set: <name>
+  - writePaths likely include src/app/api/billing/**
+
+Tier 1 means:
+  - canaryPlan block required (metrics, thresholds, rollback trigger, window)
+  - 15-min minimum delay window before afk-ready (30 min sensitive)
+  - Adversarial review must complete before label
+
+Confirm Tier 1, downgrade, or pause to discuss?
+```
+
+Do not silently set the tier — confirm with the user and pass their
+choice to `/draft-contract` so the draft is built right.
+
+## AI disclaimer for Linear comments
+
+Every Linear comment this skill posts (status announcements, stage
+hand-offs, attestation confirmations) starts on its own line with:
+
+```
+> *This was generated by AI during triage.*
+```
+
+The skill posts comments at: end of Stage 4 (draft created), end of
+Stage 7 (attestation in place). It does **not** post per-stage chatter —
+Linear is for durable status, not progress reports.
+
+Local files (the contract draft, the attestation record, debug scripts)
+carry their own provenance via git history; no disclaimer needed.
+
+## Self-validation before declaring done
+
+When the skill reaches Stage 8 hand-off, check:
+
+- [ ] `.goal-contract.yml` exists at repo root, parses as YAML, no
+      `<PLANNER_SUGGESTED:>` tokens.
+- [ ] `.afk/attestations/<linearIssueId>.json` exists, parses, and
+      validates against the v1 schema.
+- [ ] `attestedContentSha` in the record == `sha256:` + sha256 of current
+      `.goal-contract.yml` bytes.
+- [ ] No `.goal-contract.draft.yml` lingering in the working tree.
+- [ ] Tier in the contract matches the recommendation made in Stage 4.
+- [ ] For Tier 1: `canaryPlan` block is non-empty and has metrics,
+      thresholds, rollbackTrigger, windowMinutes.
+- [ ] Linear issue has the Agent Brief comment + `ready-for-agent` label
+      + status `Todo`.
+
+If any check fails, do not print the hand-off block. Surface the
+specific failure and the remediation path.
+
+## Non-goals
+
+- **No `afk-ready` label application.** §G1.
+- **No pre-flight invocation.** Pipeline triggers on the label, not on
+  this skill.
+- **No scope-PR creation.** Separate operation; the user opens the PR by
+  hand.
+- **No token auto-fill.** §G8.
+- **No file-level rename of draft → final.** §G8.
+- **No canonical YAML normalization.** Raw-bytes sha is authoritative for
+  now, per the keying decision in [`/attest`](../attest/SKILL.md).
+- **No status change to `In Progress` / `In Review` / `Reviewed`.** Those
+  belong to active development work, downstream of this skill.
+- **No editing of the goal-contract by this skill.** All authoring goes
+  through `/draft-contract` or the human directly.
+
+## References
+
+- [`../linear-triage/SKILL.md`](../linear-triage/SKILL.md) — Stage 1.
+- [`../diagnose/SKILL.md`](../diagnose/SKILL.md) — Stage 2.
+- [`../feedback-loop/SKILL.md`](../feedback-loop/SKILL.md) — invoked
+  inside `/diagnose` Phase 1.
+- [Matt Pocock's `/grill-with-docs`](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md) — Stage 3.
+- [`../draft-contract/SKILL.md`](../draft-contract/SKILL.md) — Stage 4.
+- [`../attest/SKILL.md`](../attest/SKILL.md) — Stage 7.
+- [`./state-machine.md`](./state-machine.md) — full resume-point detection
+  rules.
+- `valesco-platform/docs/afk/governance-plan.md` §G1 (label discipline —
+  why this skill never applies `afk-ready`).
+- `valesco-platform/docs/afk/governance-plan.md` §G8 (planner→main token
+  gate — why tokens stay tokens until a human replaces them).
+- `valesco-platform/docs/afk/governance-plan.md` §G10 (Tier-1 canaryPlan
+  requirement).
+- `valesco-platform/docs/afk/governance-plan.md` §14.3 (control-plane
+  self-modification refusal).

--- a/brief-to-contract/state-machine.md
+++ b/brief-to-contract/state-machine.md
@@ -1,0 +1,188 @@
+# State machine — resume-point detection
+
+Detail for [`SKILL.md`](./SKILL.md). The orchestration spine has eight
+stages and is **idempotent on each invocation** — re-running the skill
+on the same Linear issue should land at the right stage, never redo
+work, and refuse to advance through a structural gate.
+
+The detection rules below are evaluated **top-to-bottom on every
+invocation**. The first rule that matches sets the entry stage.
+
+## Detection table
+
+Read in order. Stop at the first match.
+
+| # | Detection signal | Entry | Confirmation prompt |
+|---|---|---|---|
+| 1 | `.afk/config.yml` is missing OR `afkEligible: false` | Refuse | "This repo is a control plane (or unlinked). Routing to `/linear-triage` for `ready-for-human`." |
+| 2 | `.afk/attestations/<linearIssueId>.json` exists AND its `attestedContentSha` matches `sha256:` + sha256 of current `.goal-contract.yml` bytes | Stage 8 | "Already attested for `<TEAM-NNN>`. Sha matches. Printing hand-off — confirm OK?" |
+| 3 | `.afk/attestations/<linearIssueId>.json` exists BUT sha does not match current YAML | Stage 7 | "Attestation exists but the YAML drifted (sha mismatch). I will re-attest. Confirm OK?" |
+| 4 | `.goal-contract.yml` exists, no `<PLANNER_SUGGESTED:>` tokens, no attestation record | Stage 7 | "Contract authored, ready for attestation. Entering /attest. Confirm OK?" |
+| 5 | `.goal-contract.yml` exists AND any `<PLANNER_SUGGESTED:>` tokens remain | Refuse | "Contract has unreplaced tokens at lines `<list>`. Replace them, then re-run me. I will not auto-fill." |
+| 6 | Both `.goal-contract.yml` AND `.goal-contract.draft.yml` exist | Refuse | "Both files exist — that's a dangerous state. Pick one: keep the draft and delete the final, or vice versa. Then re-run." |
+| 7 | `.goal-contract.draft.yml` exists, no `.goal-contract.yml` | Stage 5 | "Draft in place. Listing unreplaced tokens for you to address. Confirm OK?" |
+| 8 | Linear issue is `In Progress` / `In Review` / `Reviewed` | Read-only | "Issue is in active work. This skill is read-only on those statuses. Showing current state only." |
+| 9 | Linear issue is `Done` / `Canceled` / `Duplicate` | Read-only | "Issue is closed (`<status>`). Nothing for the chain to do. Showing the resolution." |
+| 10 | Linear issue is `Backlog` | Read-only | "Issue parked in Backlog. Re-triage it via `/linear-triage` to bring it back into the funnel before running me." |
+| 11 | Linear issue is `Todo` AND has `ready-for-human` label | Read-only HITL | "This issue is HITL — work it manually, not through AFK. Showing the human-brief from the triage comment." |
+| 12 | Linear issue is `Todo` AND has `ready-for-agent` label AND has an Agent Brief comment AND category is `Bug` AND brief lacks captured reproducer (per Stage 2 detection) | Stage 2 | "Brief in place but no captured reproducer. Entering `/diagnose`. Confirm OK?" |
+| 13 | Linear issue is `Todo` AND has `ready-for-agent` AND has Agent Brief AND (category is not `Bug` OR reproducer is captured) AND domain alignment looks suspect (per Stage 3 heuristics) | Stage 3 | "Brief in place; one or more domain terms / decisions need locking down. Entering `/grill-with-docs`. Confirm OK or skip?" |
+| 14 | Linear issue is `Todo` AND has `ready-for-agent` AND has Agent Brief AND nothing further is needed pre-draft | Stage 4 | "Brief is solid. Entering `/draft-contract`. Confirm tier recommendation: `<tier>` (`<reason>`)." |
+| 15 | Linear issue is `Triage` or `needs-info` (any other shape) | Stage 1 | "Issue not yet brief-ready. Entering `/linear-triage`. Confirm OK?" |
+
+If none of the above matches, refuse and surface the issue's current
+labels + status — something unexpected is going on, and the user should
+look before the skill acts.
+
+## Detection-rule notes
+
+### Rule 2 vs Rule 4 — sha computation
+
+Both rules compute `sha256:` + sha256 of the **raw bytes** of
+`.goal-contract.yml`. No canonicalization. This matches the keying
+decision in [`/attest`](../attest/SKILL.md) — the contract is the bytes,
+not a normalized form.
+
+If the file has trailing-newline drift between editors, the sha will
+differ and the skill will fall into Rule 3 (re-attest). That's correct:
+any byte-level edit invalidates the attestation per §G1.
+
+### Rule 5 — token detection
+
+Grep the YAML bytes for the literal substring `<PLANNER_SUGGESTED:`. Do
+not try to parse the YAML first — partial-replacement states (where the
+user replaced some tokens but left others) are common, and YAML may
+parse fine while still containing token strings.
+
+The detection captures and reports each line containing a token, so the
+user sees exactly what's left.
+
+### Rule 6 — both files present
+
+This state is dangerous because:
+
+- The draft may have a different sha than the final, leading to
+  attestation against the wrong content.
+- Pre-flight will validate `.goal-contract.yml` but the user may have
+  been editing `.goal-contract.draft.yml` instead.
+- It's a sign of a broken Stage 6 — the rename was done by copy-paste
+  and the draft was never deleted.
+
+Refuse to advance until the user resolves it. Don't pick for them — the
+right resolution depends on whether the user has continued editing the
+draft after creating the final.
+
+### Rules 8–11 — read-only states
+
+The skill never mutates issues that have left the triage funnel. For
+those statuses, print the current state in a single block:
+
+```
+<TEAM-NNN> "<title>"
+  status: <Linear status>
+  labels: <comma-separated>
+  category: <Bug|Feature|Improvement>
+  state:    <ready-for-agent|ready-for-human|needs-info|none>
+
+Briefs / artefacts in place:
+  - Agent Brief comment: <yes/no>
+  - .goal-contract.draft.yml: <yes/no>
+  - .goal-contract.yml: <yes/no>
+  - .afk/attestations/<id>.json: <yes/no, sha-match-yes/no>
+
+This skill is read-only here. <reason from rule>.
+```
+
+### Rule 12 — bug-without-reproducer detection
+
+The Agent Brief is considered to have a captured reproducer if **any**
+of the following is true:
+
+- The brief includes a fenced code block under a heading like
+  `## Reproducer`, `## Repro`, or `## Feedback loop`.
+- The brief references a path under `scripts/debug/`, `tests/`, or a
+  test framework's conventional location (e.g. `*.test.ts`,
+  `*_test.py`).
+- An `intent.successCriteria`-shaped bullet describes a verifiable
+  observation (≥ 5 chars, contains "When …" or "expect …" phrasing).
+
+If none holds, treat the bug as un-reproduced and route to `/diagnose`.
+
+### Rule 13 — domain-alignment suspicion
+
+Heuristics for "looks suspect":
+
+- The brief uses a noun the project has no glossary entry for, where
+  ambiguity is plausible (e.g. uses "user" when the codebase has both
+  `Customer` and `User` types).
+- The brief mentions `should ` followed by an architectural pattern
+  (event-sourced, queue-based, batch, etc.) that no ADR has decided on.
+- A Tier-1 brief whose `intent.description` is < 200 chars total — too
+  thin to give an AFK runner enough to work with.
+
+These are heuristics, not rules. The user can confirm "skip the grill"
+and the skill respects that — domain alignment is genuine work, not
+mandatory ceremony.
+
+### Rule 14 — entering Stage 4 with tier recommendation
+
+The detection rule fires only after Stages 2 and 3 are confirmed
+unnecessary. The confirmation prompt includes the tier recommendation
+inline because tier choice changes the draft's contents — a confirmed
+recommendation feeds straight into `/draft-contract`'s Tier-1 / Tier-2 /
+Tier-3 default selection.
+
+Tier reasoning the prompt should always cite:
+
+| Tier 1 reason | Source |
+|---|---|
+| `customer` field set on the issue | Linear API |
+| Project itself is Tier 1 in `.afk/config.yml` | Pre-flight |
+| Likely `writePaths` touch `**/auth/**`, `**/billing/**`, `**/migrations/**`, `supabase/migrations/**`, `src/**/payment*` | Brief inference |
+| Issue body mentions "production", "client-critical", an incident ID | Linear body parse |
+
+Single hit → escalate and ask. Multiple hits → escalate and ask, with
+all reasons listed.
+
+## Override rules
+
+The user can override the detected entry stage. Allowed overrides:
+
+- **Earlier stage** (e.g. detected Stage 7, user wants to redo Stage 4):
+  prompt for a reason, then proceed. Earlier overrides imply the user
+  is aware the existing artefacts will be re-created or invalidated.
+  Make that explicit:
+
+  > Re-entering Stage `<N>` will likely invalidate the existing
+  > `<artefact>`. Confirm?
+
+- **Later stage** (e.g. detected Stage 4, user wants to skip to Stage 7):
+  **refuse**. Skipping a structural gate defeats the purpose of the
+  spine. The user can invoke the per-stage skill (e.g. `/attest`)
+  directly if they want to bypass.
+
+- **Read-only override** (e.g. detected `In Progress`, user wants to
+  re-attest because something changed): refuse. Active-work statuses
+  belong to the developer doing the work, not to this skill.
+
+When refusing an override, point at the per-stage skill the user can
+invoke directly. The orchestration spine refusing an override is not the
+same as the user being blocked.
+
+## What this state machine does NOT track
+
+- **Time / delay window** — the tier-appropriate delay between Stage 7
+  and the user applying `afk-ready` is **not** tracked here. The
+  governance plan §G1 puts that gate in the label handler, not in this
+  skill.
+- **Adversarial review status** — that's a pipeline concern, recorded by
+  the audit store (per §G1). The attestation record carries a breadcrumb
+  (`adversarialReviewStatus: reviewed | pending | not-run`) but this
+  skill does not gate on its value.
+- **PR open/closed** — the scope PR is opened by the user after Stage 8.
+  This skill never reads PR state.
+- **CI status** — same; CI runs on the PR, downstream of this skill.
+
+If any of those cross into scope, they belong in pipeline code at
+`valesco-platform/afk/`, not here. The skills-vs-pipeline rule is
+load-bearing.

--- a/diagnose/SKILL.md
+++ b/diagnose/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: diagnose
+description: Disciplined diagnosis loop for hard bugs and performance regressions inside the Valesco AFK pipeline. Reproduce → hypothesise → instrument → fix → regression-test, with Phase 1 (build a feedback loop) load-bearing. Use when the user says "diagnose this", "debug this", "reproduce this bug", "this is throwing/failing/broken in prod", "why is this slow", or describes a performance regression. Distinct from `/linear-triage` (which decides whether a bug has enough information to be tractable at all) and `/draft-contract` (which lifts an already-diagnosed issue into a goal-contract). Run this AFTER triage has confirmed the issue is real, BEFORE drafting a contract — the feedback loop you build here is a candidate verifier for the contract's `verification.commands`, and the regression test you write seeds `intent.successCriteria`.
+---
+
+# /diagnose
+
+A discipline for hard bugs. Six phases; **Phase 1 is the skill** — everything
+else is mechanical once you have a deterministic, agent-runnable pass/fail
+signal for the bug. Skip phases only when you can articulate why.
+
+This skill is advisory. It never mutates AFK authority records (no contract
+edits, no attestation writes, no label changes). Its outputs are intended to
+feed the next skill in the chain — see [§ Outputs](#outputs-that-flow-downstream).
+
+## When to run
+
+After [`/linear-triage`](../linear-triage/SKILL.md) has classified the issue
+as a `Bug` with enough detail to attempt reproduction, but **before**
+[`/draft-contract`](../draft-contract/SKILL.md) lifts it into
+`.goal-contract.draft.yml`. A contract drafted from an undiagnosed bug almost
+always has weak `successCriteria` and no real verifier — pre-flight will
+accept it, and the AFK run will produce code that "passes" without proving
+anything.
+
+Also valid: standalone debugging during HITL work, where the bug never makes
+it to a contract. The phases still apply.
+
+## When NOT to run
+
+- The reporter's body lacks reproduction steps and the code path is unclear
+  → run [`/linear-triage`](../linear-triage/SKILL.md) and post `needs-info`
+  with specific questions instead.
+- The bug is already reproducing in CI — Phase 1 is mostly free; jump to
+  Phase 3.
+- The "bug" is actually a missing feature — this is `Feature`/`Improvement`
+  work, not diagnosis. Run [`/grill-with-docs`](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md)
+  → `/to-prd` → `/to-issues` instead.
+
+## Pre-flight — read AFK context
+
+Before Phase 1, read `.afk/config.yml` at the working repo root:
+
+| Field | Effect on diagnosis |
+|---|---|
+| `afkEligible: false` | The repo is a control plane (e.g. `valesco-platform`). Diagnose still runs, but the loop you build will feed a **human** PR, not an AFK contract. Skip the contract-handoff steps in [§ Outputs](#outputs-that-flow-downstream). |
+| `afkEligible: true` + `projectTier: 1` | Production / client-critical. The feedback loop you build is a **load-bearing** verifier. Be aggressive about determinism — flaky verifiers on Tier 1 are unacceptable per governance plan §G10. |
+| `afkEligible: true` + `projectTier: 2` or `3` | Standard discipline applies. |
+| missing | Surface to the maintainer before continuing. |
+
+Also: read [`CONTEXT.md`](../docs/workflow.md#contextmd--ubiquitous-language)
+for the project's domain glossary, and skim [`docs/adr/`](../docs/workflow.md#adrs)
+for any architectural decision in the area you're touching. Use the glossary
+vocabulary in everything you write — test names, log prefixes, hypothesis
+text — so downstream skills (`/draft-contract`, `/to-issues`) inherit
+consistent language.
+
+## Phase 1 — Build a feedback loop
+
+**This is the skill.** If you have a fast, deterministic, agent-runnable
+pass/fail signal for the bug, you will find the cause — bisection,
+hypothesis-testing, and instrumentation all just consume that signal. If
+you don't have one, no amount of staring at code will save you.
+
+Spend disproportionate effort here. **Be aggressive. Be creative. Refuse
+to give up.**
+
+### Ten patterns, in roughly this order
+
+Try them in order; stop at the first one that works for this bug. Deep
+detail on each lives in [`/feedback-loop`](../feedback-loop/SKILL.md) — that
+sibling skill is the reference for *constructing* loops; this skill is the
+reference for *using* them inside a diagnosis.
+
+1. **Failing test** at whatever seam reaches the bug — unit, integration, e2e.
+2. **Curl / HTTP script** against a running dev server.
+3. **CLI fixture diff** — invoke the CLI with a known input, diff stdout
+   against a recorded snapshot.
+4. **Headless browser script** (Playwright / Puppeteer) — drives the UI,
+   asserts on DOM / console / network.
+5. **Replay a captured trace** — save a real network request / payload /
+   event log to disk; replay it through the code path in isolation.
+6. **Throwaway harness** — minimal subset of the system (one service, mocked
+   deps) exercising the bug code path with a single function call.
+7. **Property / fuzz loop** — for "sometimes wrong output" bugs, run 1000
+   random inputs and look for the failure mode.
+8. **Bisection harness** — `git bisect run` over a script that boots state X,
+   checks, repeats.
+9. **Differential loop** — same input through old-version vs new-version (or
+   two configs); diff outputs.
+10. **HITL bash** — last resort. Drive the human via
+    `scripts/hitl-loop.template.sh` so the loop is still structured. Captured
+    output feeds back to the agent.
+
+### Iterate on the loop itself
+
+The loop is a product. Once you have *a* loop, ask:
+
+- **Faster?** Cache setup, skip unrelated init, narrow scope.
+- **Sharper?** Assert on the specific symptom, not "didn't crash".
+- **More deterministic?** Pin time, seed RNG, isolate filesystem, freeze
+  network.
+
+A 30-second flaky loop is barely better than no loop. A 2-second
+deterministic loop is a debugging superpower — and on Tier 1, anything less
+disqualifies it as a verifier.
+
+### Non-deterministic bugs
+
+The goal is not a clean repro but a **higher reproduction rate**. Loop the
+trigger 100×, parallelise, add stress, narrow timing windows, inject
+sleeps. A 50%-flake bug is debuggable; 1% is not — keep raising the rate
+until it's debuggable.
+
+### When you genuinely cannot build a loop
+
+Stop. Do **not** proceed to hypothesise. Output:
+
+> Cannot construct a feedback loop. Tried: <list>. Need one of:
+>   (a) access to the environment that reproduces it,
+>   (b) a captured artifact (HAR, log dump, core dump, screen recording with
+>       timestamps),
+>   (c) permission to add temporary production instrumentation.
+>
+> Recommend handing back to `/linear-triage` to apply `needs-info` with these
+> as the specific blockers.
+
+This is the right answer. Hypothesising without a loop produces plausible
+fixes that don't prove anything — exactly what AFK pre-flight is supposed
+to prevent. Take the slower path.
+
+## Phase 2 — Reproduce
+
+Run the loop. Watch the bug appear. Confirm:
+
+- [ ] The loop produces the failure mode the **user** described — not a
+      different failure that happens to be nearby. Wrong bug = wrong fix.
+- [ ] The failure is reproducible across multiple runs (or, for
+      non-deterministic bugs, at a high enough rate to debug against).
+- [ ] The exact symptom (error message, wrong output, slow timing) is
+      captured so later phases can verify the fix actually addresses it.
+
+Do not proceed until you reproduce the bug.
+
+## Phase 3 — Hypothesise
+
+Generate **3–5 ranked hypotheses** before testing any of them.
+Single-hypothesis generation anchors on the first plausible idea.
+
+Each hypothesis must be **falsifiable** — state the prediction it makes:
+
+> If `<X>` is the cause, then `<changing Y>` will make the bug disappear /
+> `<changing Z>` will make it worse.
+
+If you cannot state the prediction, the hypothesis is a vibe — discard or
+sharpen it.
+
+**Show the ranked list to the user before testing.** They often have domain
+knowledge that re-ranks instantly ("we just deployed a change to #3"), or
+know hypotheses they've already ruled out. Cheap checkpoint, big time saver.
+Don't block on it — proceed with your ranking if the user is AFK.
+
+Use the [`CONTEXT.md`](../docs/workflow.md#contextmd--ubiquitous-language)
+glossary in hypothesis names so the user reads them in the project's
+language, not generic terms.
+
+## Phase 4 — Instrument
+
+Each probe maps to a specific prediction from Phase 3. **Change one variable
+at a time.**
+
+Tool preference:
+
+1. **Debugger / REPL inspection** if the env supports it. One breakpoint
+   beats ten logs.
+2. **Targeted logs** at the boundaries that distinguish hypotheses.
+3. Never "log everything and grep".
+
+**Tag every debug log** with a unique prefix, e.g. `[DEBUG-a4f2]`. Cleanup
+becomes a single grep. Untagged logs survive; tagged logs die.
+
+**Perf branch.** For performance regressions, logs are usually wrong.
+Establish a baseline measurement (timing harness, `performance.now()`,
+profiler, `EXPLAIN ANALYZE` for queries), then bisect. Measure first, fix
+second.
+
+## Phase 5 — Fix + regression test
+
+Write the regression test **before the fix** — but only if there is a
+**correct seam** for it.
+
+A correct seam exercises the **real bug pattern** as it occurs at the call
+site. If the only available seam is too shallow (a single-caller test when
+the bug needs multiple callers, a unit test that can't replicate the chain
+that triggered the bug), a regression test there gives false confidence.
+
+**If no correct seam exists, that itself is the finding.** Note it. The
+codebase architecture is preventing the bug from being locked down — flag
+this for Phase 6 and for [`/improve-codebase-architecture`](https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md).
+
+If a correct seam exists:
+
+1. Turn the minimised repro into a failing test at that seam.
+2. Watch it fail.
+3. Apply the fix.
+4. Watch it pass.
+5. Re-run the Phase 1 feedback loop against the original (un-minimised)
+   scenario.
+
+## Phase 6 — Cleanup + post-mortem
+
+Required before declaring done:
+
+- [ ] Original repro no longer reproduces (re-run the Phase 1 loop).
+- [ ] Regression test passes (or absence of seam is documented).
+- [ ] All `[DEBUG-...]` instrumentation removed (`grep` the prefix).
+- [ ] Throwaway prototypes deleted (or moved to a clearly-marked debug
+      location like `scripts/debug/`).
+- [ ] The hypothesis that turned out correct is stated in the commit / PR
+      message — so the next debugger learns.
+
+**Then ask: what would have prevented this bug?** If the answer involves
+architectural change (no good test seam, tangled callers, hidden coupling),
+hand off to [`/improve-codebase-architecture`](https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md)
+with the specifics. Make the recommendation **after** the fix is in, not
+before — you have more information now than when you started.
+
+If the bug surfaced an architectural decision worth recording (a non-obvious
+constraint that future debuggers should know), offer an ADR via
+[`/grill-with-docs`](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md).
+Same three-condition rule: hard to reverse, surprising without context,
+result of a real trade-off.
+
+## Outputs that flow downstream
+
+The whole point of doing this before contract drafting is that the artefacts
+have downstream consumers. After Phase 6, hand the user a structured summary
+they can paste into Linear or feed to the next skill.
+
+| Artefact from this run | Where it goes next |
+|---|---|
+| The Phase 1 feedback loop (script / test / harness) | Becomes a candidate `verification.commands` entry in the goal-contract — the AFK run will execute it and pre-flight requires it to be deterministic. Reference it explicitly when invoking `/draft-contract`. |
+| The Phase 5 regression test | Seeds an `intent.successCriteria` bullet — phrase it as "When `<scenario>`, the system produces `<observation>`" so it round-trips through the schema's ≥ 5-char testable rule. |
+| The hypothesis that turned out correct | Goes in the Linear comment / PR description as the post-mortem one-liner. |
+| Architectural finding (no good seam, etc.) | Open a separate Linear issue tagged `Improvement` and route through `/to-issues` → `/linear-triage`. Do **not** bundle architectural work into the bug-fix contract. |
+| New domain term encountered | Update [`CONTEXT.md`](../docs/workflow.md#contextmd--ubiquitous-language) right there — same discipline as `/grill-with-docs`. Lazy-create the file if it doesn't exist. |
+
+If `afkEligible: false`, the first two rows do not apply — feed straight to
+a human PR instead.
+
+## AI disclaimer
+
+When this skill posts a comment to Linear (e.g. summarising the diagnosis
+for a Bug issue before handing back to triage), the comment **must** start
+with this disclaimer on its own line, before any other content:
+
+```
+> *This was generated by AI during diagnosis.*
+```
+
+When the skill writes only to local files (the regression test, the
+feedback loop script, debug logs), no disclaimer is needed — those carry
+their own provenance via git history.
+
+## Non-goals
+
+- **No contract authoring.** Output feeds [`/draft-contract`](../draft-contract/SKILL.md);
+  this skill never writes `.goal-contract*.yml`.
+- **No attestation.** Diagnosis is upstream of attestation — see
+  [`/attest`](../attest/SKILL.md).
+- **No label transitions.** Status / label moves on Linear are
+  [`/linear-triage`](../linear-triage/SKILL.md)'s job. This skill may
+  *recommend* a transition (e.g. "looks ready for `/draft-contract`") but
+  applies nothing itself.
+- **No production instrumentation without explicit user approval.** Phase 4
+  logs are local; production probes need the user to say yes per the
+  governance plan's protected-paths convention.
+- **No architectural refactoring inline.** Phase 5 may *note* that the
+  architecture blocks a regression test, but the actual restructuring is a
+  separate skill invocation, not an extension of this one.
+
+## References
+
+- [`../linear-triage/SKILL.md`](../linear-triage/SKILL.md) — upstream
+  (decides whether a bug is even tractable).
+- [`../feedback-loop/SKILL.md`](../feedback-loop/SKILL.md) — sibling
+  reference on constructing loops; pattern detail for the ten approaches in
+  Phase 1.
+- [`../draft-contract/SKILL.md`](../draft-contract/SKILL.md) — downstream
+  (lifts a diagnosed bug into a goal-contract).
+- [`../attest/SKILL.md`](../attest/SKILL.md) — gates the contract.
+- [Matt Pocock's `diagnose`](https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md)
+  — upstream inspiration for the six-phase loop. The phases here are the
+  same; the AFK / Linear / contract integration is what's added.
+- `valesco-platform/docs/afk/governance-plan.md` §G8 (planner → main handoff
+  — why a contract drafted from an undiagnosed bug is structurally weak).
+- `valesco-platform/docs/afk/governance-plan.md` §G10 (Tier-1 verifier
+  determinism requirement).

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -1,76 +1,60 @@
 # Gap register
 
 Skills Valesco knows it will need but has not authored yet. Entries are
-registered when the gap first blocks or slows a real run; speculative entries
-are avoided — if it hasn't bitten, it's not here.
+registered when the gap first blocks or slows a real run; speculative
+entries are avoided — if it hasn't bitten, it's not here.
 
 Each entry:
+
 - **Name** — proposed skill name.
 - **Purpose** — one line on what it does.
-- **Trigger-to-author** — condition under which we stop registering and start
-  authoring.
-- **Classification** — `skill` (advisory, user-invoked) or `pipeline` (belongs
-  in `valesco-platform/afk/` instead, registered here only for cross-reference).
+- **Trigger-to-author** — condition under which we stop registering and
+  start authoring.
+- **Classification** — `skill` (advisory, user-invoked) or `pipeline`
+  (belongs in `valesco-platform/afk/` instead, registered here only for
+  cross-reference).
 - **Tracking** — Linear issue if one exists.
 
 ---
 
 ## Open skill gaps
 
-### `/attest` — **in progress**
-
-- **Purpose**: Render the attestation checklist from a `.goal-contract.yml`
-  and walk the user through tick-through (time-delay acknowledgement,
-  protected-path confirmation, cost-estimate acknowledgement, tier-specific
-  extras like canary plan on Tier 1). Emits an attestation record that the
-  afk-ready label handler reads to decide whether to promote the contract.
-- **Status**: Skill + schema authored 2026-04-22. Schema ships via
-  valesco-platform PR [#31](https://github.com/ValescoAgency/valesco-platform/pull/31)
-  (`afk/schemas/attestation-record.v1.json` + 26 AJV tests). Skill files
-  (`attest/SKILL.md`, `checklist.md`, `record-reference.md`) on this PR.
-- **Keying decision**: records keyed by `linearIssueId`, not by canonical
-  `contractHash`. `attestedContentSha` (raw SHA-256 of
-  `.goal-contract.yml` bytes) carries integrity; the label handler
-  re-computes and rejects on drift. Canonical normalization is a
-  separate future concern.
-- **Classification**: skill (the checklist is advisory; the _record_ it
-  produces is consumed by pipeline, which is authority).
-- **Tracking**: [VA-160](https://linear.app/valescoagency/issue/VA-160).
-
 ### `/preflight-report`
 
-- **Purpose**: Render a human-readable summary of a pre-flight run's output
-  (structural checks, churn, Supabase advisors, cost estimate) for quick
-  review before approval. Pipeline already emits structured output; this
-  skill wraps it for chat.
-- **Trigger-to-author**: When raw pre-flight output becomes noisy enough to
-  slow down approvals. Defer until proven.
+- **Purpose**: Render a human-readable summary of a pre-flight run's
+  output (structural checks, churn, Supabase advisors, cost estimate)
+  for quick review before approval. Pipeline already emits structured
+  output; this skill wraps it for chat.
+- **Trigger-to-author**: When raw pre-flight output becomes noisy enough
+  to slow down approvals. Defer until proven.
 - **Classification**: skill.
 - **Tracking**: none yet.
 
-### Anthropic `write-a-skill` variant
+### Linear-native variants of `/to-prd` and `/to-issues`
 
-- **Purpose**: Anthropic publishes a skill authoring skill (likely
-  `anthropic-skills:skill-creator` or the `skill-creator` namespace). Compare
-  against Matt Pocock's `write-a-skill` and pick the better fit for Valesco
-  authoring ergonomics.
-- **Trigger-to-author**: When authoring the first Valesco skill (any of the
-  above). Choose one; don't run both in parallel.
-- **Classification**: decision, not new skill. Log the choice here when made.
-- **Tracking**: none.
+- **Purpose**: Matt's `/to-prd` and `/to-issues` use GitHub by default
+  and route Linear through the "Other" issue-tracker fallback. That
+  works but requires per-invocation freeform-prose configuration. A
+  Valesco-flavored variant would lock in Linear MCP, the VA/MREG/FMF
+  team mapping, and the AFK-eligibility check.
+- **Trigger-to-author**: When the freeform-prose fallback produces drift
+  twice in a row, or when Matt adds first-class Linear support and we
+  want to compose with that instead.
+- **Classification**: skill.
+- **Tracking**: none yet.
 
 ---
 
 ## Cross-reference — pipeline items (not skills)
 
-Registered here so skill work doesn't accidentally take them on. These belong
-in `valesco-platform/afk/`.
+Registered here so skill work doesn't accidentally take them on. These
+belong in `valesco-platform/afk/`.
 
 ### Adversarial pairing runner
 
-- **Purpose**: Runs two agents on the same contract with different prompts /
-  seeds, diffs outputs, flags divergence. Per G1 of the governance plan,
-  runs on every contract.
+- **Purpose**: Runs two agents on the same contract with different
+  prompts / seeds, diffs outputs, flags divergence. Per G1 of the
+  governance plan, runs on every contract.
 - **Why pipeline**: Produces audit records; output is authority-bearing
   (gates `afk-ready` readiness signals).
 - **Tracking**: [VA-157](https://linear.app/valescoagency/issue/VA-157)
@@ -78,43 +62,111 @@ in `valesco-platform/afk/`.
 
 ### Stage-gate enforcer
 
-- **Purpose**: Enforces "cannot apply `afk-ready` label until delay elapsed
-  AND attestation green AND adversarial review green." Per G1 + G8.
+- **Purpose**: Enforces "cannot apply `afk-ready` label until delay
+  elapsed AND attestation green AND adversarial review green." Per G1 +
+  G8.
 - **Why pipeline**: Hash-bound; gates authority transition.
 - **Tracking**: [VA-157](https://linear.app/valescoagency/issue/VA-157)
   (research); implementation ticket TBD.
 
 ### Sequential chain runner
 
-- **Purpose**: Plan → implement → test → review with state handoff between
-  stages. Distinct from Ralph's stateless loop.
+- **Purpose**: Plan → implement → test → review with state handoff
+  between stages. Distinct from Ralph's stateless loop.
 - **Why pipeline**: Consumes + produces `.goal-contract.yml` authority
-  artifacts.
+  artefacts.
 - **Tracking**: [VA-157](https://linear.app/valescoagency/issue/VA-157).
 
 ### Parallel fan-out + merge
 
-- **Purpose**: Split `write_paths` by concern (API / DB / UI / tests), run
-  specialist per lane, merge, re-validate.
-- **Why pipeline**: Merge step is authority-bearing — determines final diff
-  submitted to validator.
+- **Purpose**: Split `write_paths` by concern (API / DB / UI / tests),
+  run specialist per lane, merge, re-validate.
+- **Why pipeline**: Merge step is authority-bearing — determines final
+  diff submitted to validator.
 - **Tracking**: [VA-157](https://linear.app/valescoagency/issue/VA-157).
+
+### Containerized AFK runner (Sandcastle-shaped)
+
+- **Purpose**: Long-running AFK runs in an ephemeral container per Matt
+  Pocock's [sandcastle](https://github.com/mattpocock/sandcastle) shape.
+  Driven from a `ready-for-agent`-tagged Linear issue once attestation
+  is green.
+- **Why pipeline**: Executes the contract's `verification.commands` and
+  produces audit records that flow into the label handler. Hash-bound.
+- **Tracking**: none yet — research item.
 
 ---
 
 ## Closed gaps
 
+### `/diagnose` — shipped 2026-05-01
+
+- **Ships**: `diagnose/SKILL.md`.
+- **Purpose**: Six-phase debugging discipline; Phase 1 is load-bearing
+  (build a deterministic agent-runnable feedback loop). AFK-aware via
+  `.afk/config.yml`; the loop becomes a candidate `verification.commands`
+  entry; the regression test seeds `intent.successCriteria`.
+- **Notes**: Adapts Matt Pocock's
+  [`/diagnose`](https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md)
+  with AFK / Linear / contract integration layered on. Defers
+  feedback-loop pattern detail to the sibling `/feedback-loop` skill.
+
+### `/feedback-loop` — shipped 2026-05-01
+
+- **Ships**: `feedback-loop/SKILL.md`.
+- **Purpose**: 10-pattern catalog for constructing deterministic
+  agent-runnable signals (failing test, curl harness, CLI fixture diff,
+  headless browser, replay trace, throwaway harness, property/fuzz,
+  bisection, differential, HITL bash) plus the iteration ladder for
+  hardening any pattern against flakes.
+- **Notes**: Cited from `/diagnose` Phase 1, `/tdd` (Matt's), and
+  `/draft-contract` when authoring `verification.commands`. Tier-1
+  contracts require determinism-or-disqualified per §G10.
+
+### `/brief-to-contract` — shipped 2026-05-01
+
+- **Ships**: `brief-to-contract/SKILL.md`,
+  `brief-to-contract/state-machine.md`.
+- **Purpose**: Orchestration spine — drives a Linear issue from triage
+  through to attested contract by sequentially invoking the right
+  per-stage skills with resume detection, HITL exits, and tier
+  escalation.
+- **Notes**: Writes no authority records itself; never applies
+  `afk-ready` (§G1); never auto-fills tokens (§G8); never renames the
+  draft (§G8). The state machine has 15 detection rules evaluated
+  top-to-bottom; later-stage overrides are refused, earlier-stage
+  overrides require confirmation.
+
+### Anthropic `write-a-skill` variant — closed 2026-05-01
+
+- **Decision**: Use `anthropic-skills:skill-creator`. It's connected,
+  richer (eval loop, description optimization, packaging), and matches
+  the Valesco authoring ergonomics for these orchestration-heavy skills.
+- **Status**: Used to author `/diagnose`, `/feedback-loop`, and
+  `/brief-to-contract` on 2026-05-01.
+- **Notes**: Matt Pocock's `write-a-skill` remains in his productivity
+  bucket; we don't run both in parallel. Revisit if `skill-creator` ever
+  becomes unavailable or if Matt's variant gains specifically-better
+  ergonomics for one-off small skills.
+
+### `/attest` — shipped 2026-04-22
+
+- **Ships**: `attest/SKILL.md`, `attest/checklist.md`,
+  `attest/record-reference.md`.
+- **Tracking**: [VA-160](https://linear.app/valescoagency/issue/VA-160).
+- **Notes**: Schema lives in `valesco-platform`
+  ([VA-160](https://github.com/ValescoAgency/valesco-platform/pull/31)).
+  Records keyed by `linearIssueId`; `attestedContentSha` is raw-bytes
+  sha. The label handler re-computes and rejects on drift.
+
 ### `/draft-contract` — shipped 2026-04-22
 
-- **Ships**: `draft-contract/SKILL.md`, `template.yml`, `authority-fields.md`.
+- **Ships**: `draft-contract/SKILL.md`,
+  `draft-contract/template.yml`,
+  `draft-contract/authority-fields.md`.
 - **Tracking**: [VA-154](https://linear.app/valescoagency/issue/VA-154).
-- **Landed via**: PR [#1](https://github.com/ValescoAgency/skills/pull/1)
-  (initial) + follow-up to strict-validate drafts post-VA-158 merge.
-- **Notes**: Drafts now validate cleanly against
-  `afk/schemas/goal-contract.v1.json` thanks to
-  [VA-158](https://linear.app/valescoagency/issue/VA-158) (approvedAt +
-  contractHash optional at schema level; pre-flight's
-  `structural.metadata-presence` stage enforces presence). Validator
-  policyId / policyVersion emit as defaults with `# PLANNER_SUGGESTED`
-  comments rather than tokens, since string patterns can't hold token
-  strings — matches the tier/budget precedent.
+- **Notes**: Drafts validate cleanly against
+  `afk/schemas/goal-contract.v1.json` post
+  [VA-158](https://linear.app/valescoagency/issue/VA-158).
+  `<PLANNER_SUGGESTED:>` tokens hold the §G8 gate; pre-flight rejects
+  any contract that still contains them.

--- a/docs/starter-set.md
+++ b/docs/starter-set.md
@@ -1,40 +1,79 @@
 # Starter skill set
 
-Small, defended set of Claude Code skills Valesco adopts for day-to-day work
-around the AFK pipeline. Tuned with Jason 2026-04-21; revisit when a skill
-proves redundant or a gap keeps biting.
+The defended set of Claude Code skills Valesco adopts for day-to-day work
+around the AFK pipeline. Tuned 2026-04-21; revised 2026-05-01 to align
+with Matt Pocock's reorganized [`engineering/`](https://github.com/mattpocock/skills/tree/main/skills/engineering)
+bucket and the new flightplan-owned harness/orchestration skills.
 
-The skills-vs-pipeline rule in [README](../README.md) governs every entry. If a
-skill starts creeping into authority, audit, or tier-gate territory, it moves
+The skills-vs-pipeline rule in [README](../README.md) and the workflow
+doctrine in [workflow.md](./workflow.md) govern every entry. If a skill
+starts creeping into authority, audit, or tier-gate territory, it moves
 to pipeline code at `valesco-platform/afk/` and drops off this list.
 
 ---
 
-## Adopted — core (always-on posture)
+## Adopted — flightplan-owned (Valesco)
 
-| Skill | Source | Use case in AFK-adjacent work |
+These ship in this plugin. AFK-aware; opinionated about Linear, Linear
+team mapping, and the goal-contract pipeline.
+
+| Skill | Use case |
+|---|---|
+| [`/linear-triage`](../linear-triage/SKILL.md) | Funnel Linear issues toward `ready-for-agent` with an Agent Brief comment. AFK-eligibility-aware via `.afk/config.yml`. |
+| [`/diagnose`](../diagnose/SKILL.md) | Six-phase debugging discipline; Phase 1 builds the verifier the contract will use. AFK-aware tier handling. |
+| [`/feedback-loop`](../feedback-loop/SKILL.md) | The 10-pattern catalog for constructing deterministic agent-runnable signals. Cited by `/diagnose`, `/draft-contract`, and Matt's `/tdd`. |
+| [`/draft-contract`](../draft-contract/SKILL.md) | Lift a Linear issue into `.goal-contract.draft.yml` with `<PLANNER_SUGGESTED:>` tokens (G8 gate). |
+| [`/attest`](../attest/SKILL.md) | Tier-scaled attestation checklist; writes `.afk/attestations/<id>.json` (the label handler reads it). |
+| [`/brief-to-contract`](../brief-to-contract/SKILL.md) | Orchestration spine — drives a Linear issue through the chain to attested contract with resume detection + HITL exits. |
+
+---
+
+## Adopted — upstream (Matt Pocock)
+
+Adopted from [`mattpocock/skills`](https://github.com/mattpocock/skills).
+Used as-is; configure for Valesco via `/setup-matt-pocock-skills` with
+Linear as the issue tracker (the "Other" path until/unless he adds a
+first-class Linear adapter).
+
+### Always-on alignment + planning posture
+
+| Skill | Source | Use case |
 |---|---|---|
-| `to-prd` | Matt Pocock | Authors the PRD that becomes a Linear intent issue. Upstream of any AFK contract. |
-| `grill-me` | Matt Pocock | Adversarial pass on the PRD before intent is posted. Distinct from the pipeline's adversarial reviewer — this one is user-invoked on drafts, not on contracts. |
-| `domain-model` | Matt Pocock | Domain modeling pass before a feature is sliced into issues. Output feeds PRDs + Supabase schemas. |
-| `ubiquitous-language` | Matt Pocock | Naming discipline. Pays off downstream in Supabase column names, Zod schema types, server-action names, route handlers. |
-| `triage-issue` | — | Linear triage pass. Classifies incoming issues, sets priority/labels/team. |
-| `write-a-skill` | Matt Pocock (for now) | Meta. Lets gaps get closed in-flight without filing a ticket per skill. See note on Anthropic's variant in [gaps.md](./gaps.md). |
+| [`/grill-with-docs`](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md) | Matt | Adversarial pass on a plan, with inline updates to `CONTEXT.md` and `docs/adr/`. **Replaces** `grill-me` + `domain-model` + `ubiquitous-language` from the previous starter-set — those three are now folded into one. |
+| [`/to-prd`](https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md) | Matt | Synthesize a PRD from the current conversation, post to Linear. No interview — the grill happens upstream. |
+| [`/to-issues`](https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md) | Matt | Break a PRD into vertical-slice tracer-bullet issues with HITL/AFK tags. **New since the previous starter-set** — split out from `/to-prd`. |
 
-## Adopted — user-invoked review passes
+### User-invoked review passes
 
 These do not auto-run. Invoke deliberately.
 
 | Skill | Source | When to invoke |
 |---|---|---|
-| `tdd` | Matt Pocock | Feature work where TDD is the explicit posture. Discipline — not optional once invoked. |
-| `security-and-hardening` | Addy Osmani | Review pass on auth paths, RLS policies, payment flows, any net-new surface that takes untrusted input. |
-| `performance-optimization` | Addy Osmani | Review pass when a page or action measurably regresses. Not preventive — reactive to signal. |
-| `design-an-interface` | — | Deliberate design-interface work (IA, component contracts, API shapes). User-invoked only. |
-| `frontend-ui-engineering` | Addy Osmani | UI-heavy feature work. User-invoked only — house style (Tailwind + shadcn + `react-components.md` rules) wins any conflict. |
+| [`/tdd`](https://github.com/mattpocock/skills/blob/main/skills/engineering/tdd/SKILL.md) | Matt | Feature work where TDD is the explicit posture. Vertical-slice red-green-refactor; explicit anti-pattern: no horizontal slicing. |
+| [`/improve-codebase-architecture`](https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md) | Matt | **Newly adopted (2026-05-01).** Surface deepening opportunities (Module/Interface/Depth/Seam/Adapter glossary). Run every few days, or after a `/diagnose` that surfaced an architectural blocker. The previous rejection rationale ("overlaps grill-me + domain-model") no longer holds — Matt's new version has its own architectural glossary distinct from grilling. |
+| [`/zoom-out`](https://github.com/mattpocock/skills/blob/main/skills/engineering/zoom-out/SKILL.md) | Matt | Newly adopted. One-paragraph navigation aid when entering an unfamiliar area of the codebase. |
+| [`security-and-hardening`](https://github.com/addyosmani/agent-skills) | Addy Osmani | Review pass on auth paths, RLS policies, payment flows, any net-new surface that takes untrusted input. |
+| [`performance-optimization`](https://github.com/addyosmani/agent-skills) | Addy Osmani | Review pass when a page or action measurably regresses. Reactive to signal, not preventive. |
+| [`frontend-ui-engineering`](https://github.com/addyosmani/agent-skills) | Addy Osmani | UI-heavy feature work. House style (Tailwind + shadcn + `react-components.md` rules) wins any conflict per the conflict rule. |
 
-**shadcn/ui skill**: adopted per-project, not globally. Added when a project's
-frontend surface justifies it.
+**shadcn/ui skill**: adopted per-project, not globally. Added when a
+project's frontend surface justifies it.
+
+---
+
+## Newly added Valesco repo conventions (2026-05-01)
+
+The above skills assume three repo-level conventions, established with
+this revision and described in detail in [workflow.md](./workflow.md):
+
+1. **`.afk/config.yml`** — already established for the AFK pipeline.
+2. **`CONTEXT.md`** — the project's ubiquitous language. Lazily created
+   by `/grill-with-docs` on first term resolution.
+3. **`docs/adr/`** — architectural decision records. Lazily created by
+   `/grill-with-docs` or `/improve-codebase-architecture` on first ADR.
+
+`/diagnose`, `/feedback-loop`, and `/brief-to-contract` reference these
+files directly. Existing repos backfill on first need.
 
 ---
 
@@ -42,25 +81,33 @@ frontend surface justifies it.
 
 | Skill | Decision | Rationale |
 |---|---|---|
-| `improve-codebase-architecture` | Rejected | Overlaps `grill-me` + `domain-model`. |
-| `request-refactor-plan` | Rejected | Overlaps the Plan agent / planning phase of AFK contracts. |
+| `domain-model` | Removed (deprecated upstream) | Matt folded it into `/grill-with-docs`. Use that. |
+| `ubiquitous-language` | Removed (deprecated upstream) | Same — folded into `/grill-with-docs`. |
+| `design-an-interface` | Removed (deprecated upstream) | Matt deprecated this; the deepening work happens in `/improve-codebase-architecture` now. |
+| `request-refactor-plan` | Rejected | Overlaps `/improve-codebase-architecture` and the Plan agent / planning phase of AFK contracts. |
 | `git-guardrails-claude-code` | Rejected | Lefthook + branch protection cover this mechanically per `workflow.md` §7. Skill would duplicate without adding authority. |
 | `obsidian`, `obsidian-vault` | Out of scope | Personal knowledge workflow, orthogonal to AFK. |
 | `caveman` | N/A | Response style, not a workflow skill. Loaded per session. |
+| `/setup-matt-pocock-skills` | Skip | Valesco repos already follow the conventions this skill bootstraps. Run it only on a brand-new project that isn't using the Valesco template. |
 
 ---
 
 ## Conflict rule
 
 If a skill's output contradicts the house rules in
-`~/.claude/rules/*.md` or `valesco-platform/docs/afk/governance-plan.md`,
-**the rules win**. Skill output is advisory; rules are authority.
+`~/.claude/rules/*.md`, the governance plan in
+`valesco-platform/docs/afk/governance-plan.md`, or an ADR in `docs/adr/`,
+**the rules / governance / ADR win.** Skill output is advisory; those
+three are authority. Log persistent conflicts as a revisit trigger here.
 
 ---
 
 ## Revisit triggers
 
 Revise this list when:
-- An adopted skill gets invoked fewer than 1x/month over two months → demote to rejected.
+
+- An adopted skill gets invoked fewer than 1×/month over two months → demote to rejected.
 - A rejected skill gets wanted three times → promote.
 - A gap in [gaps.md](./gaps.md) gets authored and lands → move to adopted.
+- Matt or Addy ship a substantively new skill in their engineering bucket → evaluate within a week.
+- An adopted upstream skill conflicts with house rules / governance / an ADR repeatedly → consider replacing with a Valesco-flavored variant.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,264 @@
+# Workflow — harness engineering + agent orchestration
+
+Reference for how Valesco-authored skills compose with Matt Pocock's
+engineering skills to drive a Linear issue end-to-end through the AFK
+pipeline. This is the doctrine the new flightplan skills assume; the
+[starter-set](./starter-set.md) tracks which skills are adopted and the
+[gaps](./gaps.md) doc tracks what's missing.
+
+## End-to-end map
+
+```
+idea / conversation / paste
+        │
+        ▼
+   /grill-with-docs        (Matt — alignment + glossary + ADR)
+        │
+        ▼
+        /to-prd            (Matt — synthesizes PRD from context)
+        │
+        ▼
+        /to-issues         (Matt — vertical-slice tracer-bullet issues)
+        │
+        ▼
+   ─── Linear issue exists ───────────────────────────────────────
+        │
+        ▼
+   /linear-triage          (Valesco — funnel toward ready-for-agent)
+        │
+        ├─→ ready-for-human  → HITL exit
+        ├─→ needs-info       → wait for reporter
+        └─→ ready-for-agent (Agent Brief comment posted)
+                │
+                ▼
+        /diagnose           (Valesco — Bugs only; build the Phase-1 loop)
+                │           │
+                │           └─ uses /feedback-loop for the 10 patterns
+                │
+                ▼
+        /grill-with-docs    (optional, when domain alignment looks suspect)
+                │
+                ▼
+        /draft-contract     (Valesco — lift Linear → .goal-contract.draft.yml)
+                │
+                ▼
+   ─── HUMAN: replace <PLANNER_SUGGESTED:> tokens, rename to .goal-contract.yml
+                │
+                ▼
+        /attest             (Valesco — tier-scaled checklist + record)
+                │
+                ▼
+   ─── HUMAN: open scope PR, wait delay window, apply afk-ready
+                │
+                ▼
+   AFK pipeline (valesco-platform)  — pre-flight, adversarial review, run, label handler
+```
+
+The orchestration spine, [`/brief-to-contract`](../brief-to-contract/SKILL.md),
+walks an issue from the Linear-issue line through to the attest step. It
+detects which stage to enter based on existing artefacts and exits cleanly
+on HITL forks.
+
+## Stage ownership
+
+| Stage | Skill | Source | Purpose |
+|---|---|---|---|
+| Idea → aligned plan | [`/grill-with-docs`](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md) | Matt | Alignment + locks domain language in `CONTEXT.md` + records ADRs inline |
+| Plan → PRD | [`/to-prd`](https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md) | Matt | Synthesizes a PRD from current context; posts to Linear |
+| PRD → issues | [`/to-issues`](https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md) | Matt | Breaks the PRD into vertical-slice tracer-bullet issues; tags HITL vs AFK |
+| Linear issue → ready-for-agent | [`/linear-triage`](../linear-triage/SKILL.md) | Valesco | Funnel toward `ready-for-agent` with an Agent Brief comment; HITL-aware |
+| Bug needs reproducer | [`/diagnose`](../diagnose/SKILL.md) | Valesco | Six-phase loop; Phase 1 builds the verifier the contract will use |
+| Construct a feedback loop | [`/feedback-loop`](../feedback-loop/SKILL.md) | Valesco | The 10-pattern catalog for deterministic agent-runnable signals |
+| Architecture review | [`/improve-codebase-architecture`](https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md) | Matt | Find deepening opportunities; informed by `CONTEXT.md` + ADRs |
+| Brief → draft contract | [`/draft-contract`](../draft-contract/SKILL.md) | Valesco | Lift Linear issue into `.goal-contract.draft.yml` with `<PLANNER_SUGGESTED:>` tokens |
+| Draft → attested | [`/attest`](../attest/SKILL.md) | Valesco | Tier-scaled checklist; writes `.afk/attestations/<id>.json` |
+| Whole chain | [`/brief-to-contract`](../brief-to-contract/SKILL.md) | Valesco | Orchestration spine; sequences the above with resume detection + HITL exits |
+| Pre-flight, adversarial review, run, label handler | — | `valesco-platform/afk/` | **Pipeline, not skills.** Authority-bearing, hash-bound, replay-safe. |
+
+The `/brief-to-contract` spine never crosses into pipeline territory.
+That boundary is load-bearing — see [§ Skills vs pipeline](#skills-vs-pipeline)
+below.
+
+## Repo conventions this workflow assumes
+
+For the workflow to compose cleanly, projects under
+`github.com/ValescoAgency` adopt three conventions:
+
+1. **`.afk/config.yml`** at the repo root. Declares `afkEligible`,
+   `projectTier`, customer (Tier 1), tier expiry. The pipeline reads it;
+   skills read it for their own gating.
+2. **`CONTEXT.md`** at the repo root (single-context) or
+   **`CONTEXT-MAP.md`** + per-context `CONTEXT.md` (multi-context, e.g.
+   monorepos). Holds the project's ubiquitous language. Maintained by
+   `/grill-with-docs` and `/improve-codebase-architecture`.
+3. **`docs/adr/`** at the repo root, or per-context. Records architectural
+   decisions that meet the three-condition rule: hard to reverse,
+   surprising without context, result of a real trade-off.
+
+These conventions are new as of 2026-05-01. Existing repos backfill on
+first use — `/grill-with-docs` creates `CONTEXT.md` lazily when the first
+term is resolved, and creates `docs/adr/` lazily when the first ADR is
+needed.
+
+## CONTEXT.md — Ubiquitous Language
+
+The glossary file. Every term agents and humans use to describe the
+project's domain — the Eric Evans "ubiquitous language" idea, made
+concrete as a markdown file the agent can read on session start.
+
+### What goes in
+
+- Domain nouns the project distinguishes (`Customer` vs `User`,
+  `Order` vs `Cart`, `Subscription` vs `Plan`).
+- Domain verbs that mean something specific (`materialize`, `cancel`,
+  `enroll`).
+- Concepts that have a precise project-specific meaning beyond their
+  common-English reading.
+
+### What stays out
+
+- Implementation details — class names, file paths, framework choices.
+  The glossary is what domain experts would say, not what the codebase
+  happens to be named today.
+- Things any reader of the codebase would understand without the file
+  (`User has email and password`).
+- Refactor candidates / code-review observations — those go in
+  `docs/adr/` or are addressed in the code itself.
+
+### When to update
+
+Inline, as terms are resolved during a `/grill-with-docs` or
+`/improve-codebase-architecture` run. Don't batch — capture each term
+when it first becomes contested or sharpened. Format per Matt's
+[CONTEXT-FORMAT.md](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/CONTEXT-FORMAT.md).
+
+### Why agents need this
+
+Cold-start agents (the AFK runner, sub-agents spawned by the Explore
+tool, fresh Claude Code sessions) start with no project vocabulary. They
+guess at "user" vs "customer," reinvent verbs the team has already
+named, and produce verbose code that uses 20 words where 1 will do. A
+read-on-start glossary collapses that to a paragraph.
+
+The Valesco engineering skills (`/diagnose`, `/draft-contract`,
+`/linear-triage`) reference `CONTEXT.md` so the test names, contract
+fields, and triage notes round-trip in the project's language.
+
+## ADRs
+
+Architectural Decision Records under `docs/adr/`. One file per decision,
+numbered (`0001-event-sourced-orders.md`, `0002-postgres-write-model.md`).
+
+### When an ADR is warranted
+
+All three must hold (Matt's rule, adopted as Valesco doctrine):
+
+1. **Hard to reverse** — changing your mind later costs real engineering.
+2. **Surprising without context** — a future reader will wonder "why?"
+3. **Result of a real trade-off** — there were genuine alternatives.
+
+If any of the three is missing, skip the ADR. Most decisions don't merit
+one.
+
+### What's in the file
+
+Format per Matt's
+[ADR-FORMAT.md](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/ADR-FORMAT.md).
+Short version:
+
+- Context (the trade-off as it was at decision time)
+- Decision (what was chosen)
+- Consequences (what becomes easier and harder)
+- Status (proposed / accepted / superseded by NNNN)
+
+### How AFK skills use ADRs
+
+- [`/draft-contract`](../draft-contract/SKILL.md) reads the ADR area
+  relevant to the issue's `writePaths` so the contract doesn't propose
+  changes that contradict locked-in decisions.
+- [`/diagnose`](../diagnose/SKILL.md) reads ADRs in the bug's area before
+  hypothesising — sometimes a "bug" is the documented behavior of an
+  ADR'd decision.
+- [`/improve-codebase-architecture`](https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md)
+  surfaces ADR conflicts as part of its candidate-deepening list, but
+  marks them clearly so the human can decide whether to revisit the ADR.
+- The AFK runner inherits the same posture by reading the same files.
+
+ADRs are read more often than they're written. That's the ratio you
+want — six months later they're a navigation aid, not a notebook.
+
+## HITL fork
+
+Not every issue is AFK-eligible. The pipeline is built around accepting
+that gracefully and routing to a human without losing work.
+
+| Trigger | Where it fires | Skill response |
+|---|---|---|
+| Repo is `afkEligible: false` (e.g. `valesco-platform`) | `/brief-to-contract` Stage 0 | Refuse; recommend `/linear-triage` for `ready-for-human`. |
+| Triage decides `ready-for-human` | `/linear-triage` Step 5 | Post a Human Brief (same shape as Agent Brief + a "why human, not agent" paragraph). |
+| `/diagnose` cannot build a feedback loop | Phase 1 fallback | Drop back to `/linear-triage` with `needs-info` listing the specific blockers. |
+| `<PLANNER_SUGGESTED:>` tokens reveal genuine unknowns | `/brief-to-contract` Stage 5 | Surface the unknowns; drop back to `/grill-with-docs` if they're domain questions. |
+| Tier 1 escalation declined | `/brief-to-contract` Stage 4 | Pause and discuss — the issue may need to be retagged or accepted at Tier 1 anyway. |
+| Adversarial review surfaces a real concern | Pipeline (not a skill) | Pipeline halts the run; ticket goes back to a human. |
+
+The HITL fork is a feature, not a failure. An issue routed to
+`ready-for-human` has been triaged, briefed, and (if a bug) often
+diagnosed — the human picking it up has the same context the AFK runner
+would have had.
+
+## Skills vs pipeline
+
+The boundary that gives this workflow its safety properties.
+
+**Skills** (live in this repo, advisory, user-invoked):
+
+- Can read any file.
+- Can call other skills.
+- Can post Linear comments (with the AI disclaimer).
+- Can write *user-territory* files: tests, scripts in `scripts/debug/`,
+  `CONTEXT.md`, `docs/adr/`, the goal-contract draft, the attestation
+  record.
+- Cannot mutate AFK authority records (audit store, label handler state,
+  pipeline's own data).
+- Cannot apply `afk-ready` (§G1).
+- Cannot replace `<PLANNER_SUGGESTED:>` tokens (§G8).
+
+**Pipeline** (lives in `valesco-platform/afk/`, authority-bearing):
+
+- Validators (structural, churn, advisor, cost).
+- Pre-flight orchestration.
+- Adversarial pairing runner (when implemented per §G1).
+- Label handler (re-verifies `attestedContentSha`, gates promotion).
+- Stage-gate enforcer (delay window, attestation green, adversarial
+  green).
+- Audit log writers.
+
+If a proposed capability would touch authority, audit, or hash-bound
+state, it becomes a pipeline ticket — not a skill. See
+[`docs/gaps.md`](./gaps.md) for the cross-reference list of pipeline
+items registered there only so skill work doesn't accidentally pick them
+up.
+
+## Conflict rule
+
+When skill output (Matt's or Valesco's) contradicts:
+
+- The house rules in `~/.claude/rules/*.md`,
+- The governance plan in `valesco-platform/docs/afk/governance-plan.md`,
+- An ADR in `docs/adr/`,
+
+**the rules / governance / ADR win.** Skill output is advisory; those
+three are authority. If a skill insists on a structure that violates
+them, log it as a starter-set revisit trigger in
+[`docs/starter-set.md`](./starter-set.md).
+
+## References
+
+- [`./starter-set.md`](./starter-set.md) — adopted skills, with rationale.
+- [`./gaps.md`](./gaps.md) — known-missing skills + pipeline cross-refs.
+- `valesco-platform/docs/afk/governance-plan.md` — full governance.
+- `valesco-platform/docs/sdlc/workflow.md` §8 — AFK governance section
+  of the broader SDLC.
+- [Matt Pocock's skills](https://github.com/mattpocock/skills) — upstream
+  for `/grill-with-docs`, `/to-prd`, `/to-issues`,
+  `/improve-codebase-architecture`, `/zoom-out`, `/tdd`.

--- a/feedback-loop/SKILL.md
+++ b/feedback-loop/SKILL.md
@@ -1,0 +1,471 @@
+---
+name: feedback-loop
+description: Construct a deterministic, agent-runnable pass/fail signal for a bug, regression, or feature — fast, sharp, and reproducible without a human in the loop. Use when the user says "build a test harness", "make this reproducible", "set up a verifier for this contract", "what's the cheapest reproducer for this bug", "the dev loop is too slow", or "we need a deterministic check for this". This is the reference skill the rest of the Valesco engineering chain leans on: `/diagnose` Phase 1 invokes it to find a bug's cause, `/tdd` invokes it to drive new code red→green, and `/draft-contract` invokes it when authoring the goal-contract's `verification.commands`. Distinct from `/diagnose` (which *uses* loops to locate causes) and `/tdd` (which *uses* loops to drive incremental implementation) — this skill is about *constructing* the loop itself. Whenever you find yourself debugging by re-reading code or running ad-hoc commands without a deterministic pass/fail, stop and run this.
+---
+
+# /feedback-loop
+
+Construct a fast, sharp, deterministic, agent-runnable pass/fail signal for
+the behavior under question. Pick from a catalog of ten patterns, harden
+the loop against flakes, and hand it off to whatever skill called this one.
+
+This skill is advisory. It writes test files, scripts, harnesses, and
+fixtures — never `.goal-contract*.yml`, never `.afk/attestations/`, never
+labels. The loop you build here is the *input* to those authority-bearing
+artefacts, not the artefact itself.
+
+## Why a deterministic loop is load-bearing
+
+Three things in the Valesco chain depend on the loop existing and behaving
+predictably:
+
+1. **AFK pre-flight.** The goal-contract's `verification.commands` are
+   executed unattended by the AFK runner. A flaky verifier produces flaky
+   AFK runs — bad code merges because the flake masked a real failure, or
+   good code rolls back because the flake fired on a clean diff. Per
+   governance plan §G10, Tier-1 contracts require deterministic verifiers
+   or disqualification.
+2. **`/diagnose` Phase 1.** Without a loop, hypothesis-testing degrades to
+   hand-waving. Phase 1 is the entire skill — the rest is mechanical once
+   the signal exists.
+3. **`/tdd` red→green.** A test that takes 30 seconds to fail breaks the
+   tracer-bullet rhythm; the agent stops listening to its own feedback.
+
+If you don't have a loop, you don't have engineering — you have
+storytelling. Build the loop.
+
+## When to run
+
+- Inside `/diagnose` Phase 1, when you've reproduced the bug by hand but
+  need an automatable signal.
+- Inside `/tdd`, when picking the seam for the first failing test in a new
+  feature slice.
+- Inside `/draft-contract`, when the contract needs a `verification.commands`
+  entry and the source Linear issue doesn't yet specify one.
+- Standalone, when the user says "the dev loop is too slow" — the
+  iteration ladder applies even when no specific bug is on the table.
+
+## When NOT to run
+
+- The loop already exists and runs in CI — use it; don't rebuild.
+- The "loop" the user wants is a manual checklist for stakeholders. That's
+  a runbook, not a feedback loop.
+- The bug only matters in production with real customer data. First run
+  `/linear-triage` to determine whether you have legitimate access to a
+  reproducer; this skill cannot manufacture one out of nothing.
+
+## Pre-flight — read AFK context
+
+Read `.afk/config.yml` at the working repo root to set the determinism bar:
+
+| Field | Determinism requirement |
+|---|---|
+| `afkEligible: true` + `projectTier: 1` | **Disqualified-or-deterministic.** No documented flakes accepted in `verification.commands`. Every retry attempt is a failure to root-cause. Spend the time. |
+| `afkEligible: true` + `projectTier: 2` | Documented flakes tolerated if the flake rate is < 1% and the failure mode is well-understood. Add a `# flake-budget: <reason>` comment in the verifier. |
+| `afkEligible: true` + `projectTier: 3` | Best effort. Some flakiness OK if the alternative is no loop at all. |
+| `afkEligible: false` | The loop feeds a human PR — use whatever level of determinism the human reviewer is willing to defend. |
+| missing | Surface to the maintainer before continuing. |
+
+This bar shapes which patterns are eligible (e.g., HITL bash is never a
+Tier-1 verifier — humans aren't part of the AFK runner) and how aggressively
+to climb the iteration ladder.
+
+## Three properties of a good loop
+
+Every loop, regardless of pattern, is judged on three axes. A 30-second
+flaky loop is barely better than no loop at all; a 2-second deterministic
+loop is a debugging superpower.
+
+### Fast
+
+- **Target:** under 5 seconds wall-clock per iteration.
+- **Superpower threshold:** under 2 seconds. At this speed the agent (or
+  human) iterates without losing context between cycles.
+- **Disqualifying:** over 30 seconds per iteration on Tier 1 — the AFK
+  runner's retry budget burns too quickly.
+
+How to get fast: cache setup steps (don't re-bootstrap the DB on every
+iteration), narrow the scope (run *one* test, not the whole file), skip
+unrelated init, swap heavy deps for thin fakes only at the *outer*
+boundary.
+
+### Sharp
+
+A sharp loop asserts on the **specific symptom**, not "didn't crash". If
+the bug is "wrong total when cart contains a 0-priced item", the
+assertion is `assert total == 0`, not `assert order.completed_ok`.
+
+Sharp loops survive refactors because they describe *behavior*, not
+*structure*. A loop that fails when you rename an internal function was
+testing implementation, not behavior — see [`/tdd`](https://github.com/mattpocock/skills/blob/main/skills/engineering/tdd/SKILL.md).
+
+### Deterministic
+
+Same input, same output, every run, on every machine. The four sources of
+non-determinism to neutralize:
+
+- **Time** — pin the clock (`vi.useFakeTimers()`, `freezegun`, or inject
+  a clock dependency).
+- **Randomness** — seed RNG (`Math.random` is rarely the issue; UUIDs and
+  test data factories are).
+- **Filesystem** — isolate per-test (`tmp.mkdtempSync()`, ephemeral
+  Supabase branch via `mcp__a80053c7…__create_branch`).
+- **Network** — freeze with a recorded fixture (MSW, VCR, nock) or run
+  inside a container with no egress.
+
+If you cannot neutralize one of the four, document which and why in a
+comment alongside the loop. AFK pre-flight will read it on Tier 1.
+
+## Pattern catalog
+
+Pick the cheapest pattern that produces a sharp signal. The patterns are
+ordered by general preference — when in doubt, try them in this order.
+
+### 1. Failing test
+
+A test at the seam closest to the bug — unit when behavior is local,
+integration when the bug only appears across module boundaries, e2e when
+the bug is in wiring.
+
+- **When it fits:** the codebase has a test framework, the behavior is
+  callable from test code, the bug reproduces with a small input.
+- **Pitfalls:** mocking too aggressively (the bug lives in the
+  collaboration); writing the test at the wrong seam (unit test for a
+  bug that needs three callers to trigger).
+- **Skeleton:**
+  ```
+  test("reproduces <symptom>", () => {
+    setup();
+    const result = systemUnderTest(triggeringInput);
+    expect(result).toBe(expectedSymptom); // initially the bug, then the fix
+  });
+  ```
+- **Iteration ladder:** narrow scope to one test (`vitest <file> -t <name>`),
+  skip unrelated setup hooks, switch from full DB to in-memory adapter only
+  if the bug isn't in the DB layer.
+
+### 2. Curl / HTTP harness
+
+A shell script that hits a running dev server with a recorded request and
+asserts on the response shape, status, or specific field.
+
+- **When it fits:** the bug is reachable via the public API; you have a
+  dev server you can keep running.
+- **Pitfalls:** auth tokens that expire mid-iteration; non-deterministic
+  IDs in the response (compare *shape* with `jq`, not full body diff);
+  forgetting to seed the DB to a known state between runs.
+- **Skeleton:**
+  ```bash
+  #!/usr/bin/env bash
+  set -euo pipefail
+  RESPONSE=$(curl -sS -X POST http://localhost:3000/api/orders \
+    -H "Content-Type: application/json" \
+    -d @fixtures/order.json)
+  echo "$RESPONSE" | jq -e '.total == 0' > /dev/null
+  ```
+- **Iteration ladder:** keep the server warm between runs; pre-seed the DB
+  with a snapshot; pin the auth token to a long-lived test JWT.
+
+### 3. CLI fixture diff
+
+Invoke the CLI with a fixture input file and diff stdout against a
+recorded snapshot.
+
+- **When it fits:** the system is a CLI, code generator, or text
+  transformer; output is text.
+- **Pitfalls:** newline / trailing-whitespace drift across platforms;
+  timestamps in output (filter or normalize before diffing); ANSI color
+  codes (strip with `sed -r 's/\x1b\[[0-9;]*m//g'`).
+- **Skeleton:**
+  ```bash
+  ./bin/mytool < fixtures/input.txt > /tmp/actual.txt
+  diff -u fixtures/expected.txt /tmp/actual.txt
+  ```
+- **Iteration ladder:** snapshot tooling (`vitest -u`, `insta`) instead of
+  hand-maintained expected files; canonicalize output (sort lines if order
+  doesn't matter).
+
+### 4. Headless browser script
+
+Playwright or Puppeteer drives the real UI; the script asserts on DOM
+state, console messages, or network calls.
+
+- **When it fits:** the bug is in client-side behavior, layout, or
+  browser-only APIs (IndexedDB, service workers, scroll behavior).
+- **Pitfalls:** real network calls (mock at the route level, not the
+  fetch level — closer to the network seam); racy waits (`waitForSelector`,
+  not `setTimeout`); zombie browser processes between runs.
+- **Skeleton:**
+  ```ts
+  test("cart total updates", async ({ page }) => {
+    await page.goto("/cart");
+    await page.getByRole("button", { name: /add/i }).click();
+    await expect(page.getByTestId("total")).toHaveText("$0.00");
+  });
+  ```
+- **Iteration ladder:** use Playwright's `--ui` mode for first-build,
+  drop to headless for the production loop; record video on failure only;
+  pin viewport size to make selectors stable.
+
+### 5. Replay a captured trace
+
+Save a real network request / payload / event log to disk; replay it
+through the code path in isolation.
+
+- **When it fits:** the bug only appears with production-shaped data, but
+  the data itself is reproducible (no PII, or PII can be scrubbed); race
+  conditions captured by a time-stamped event log.
+- **Pitfalls:** PII or secrets in the captured trace (sanitize before
+  committing); trace from a deployed version that no longer exists in code
+  (note the version in the fixture filename); replays that hit external
+  services (stub them).
+- **Skeleton:**
+  ```ts
+  test("processes captured webhook payload", async () => {
+    const payload = JSON.parse(fs.readFileSync("fixtures/webhook-2026-04-30.json"));
+    const result = await processWebhook(payload);
+    expect(result.status).toBe("rejected");
+  });
+  ```
+- **Iteration ladder:** trim the trace to the minimal subset that still
+  reproduces; canonicalize timestamps; commit one fixture per shape, not
+  one per occurrence.
+
+### 6. Throwaway harness
+
+A minimal subset of the system — one service, faked deps — that exercises
+the bug code path with a single function call. Lives in `scripts/debug/`,
+not in the test suite.
+
+- **When it fits:** the system is too tangled to test in place; the bug
+  spans a refactor that hasn't landed; you need to call into private
+  internals.
+- **Pitfalls:** the harness diverges from production wiring and "fixes"
+  bugs that production still has; harness becomes load-bearing
+  infrastructure (it shouldn't — Phase 6 of `/diagnose` deletes it).
+- **Skeleton:**
+  ```ts
+  // scripts/debug/repro-VA-142.ts
+  import { internalFunction } from "../../src/feature/private";
+  const result = internalFunction(buildInput());
+  if (result !== "expected") process.exit(1);
+  ```
+- **Iteration ladder:** keep the import surface minimal (you're not
+  rebuilding the system); add `console.time` blocks to find the slow part;
+  delete the harness as soon as a real test seam exists.
+
+### 7. Property / fuzz loop
+
+Run 1000+ random inputs through the system and look for the failure mode.
+
+- **When it fits:** "sometimes wrong output" bugs; serializers, parsers,
+  state machines, anything with a large input space; no obvious
+  triggering input.
+- **Pitfalls:** unbounded test time (cap with `numRuns`); shrinking
+  failures the framework can't simplify (write a custom shrinker); flakes
+  from network or time inside the property (don't — keep the property
+  pure).
+- **Skeleton:**
+  ```ts
+  fc.assert(fc.property(fc.array(fc.integer()), arr => {
+    const sorted = mySort(arr);
+    return isAscending(sorted);
+  }), { numRuns: 1000, seed: 42 });
+  ```
+- **Iteration ladder:** seed the PRNG (`seed: 42`); save the smallest
+  counterexample as a regression test; raise `numRuns` only after the
+  shrinker is reliable.
+
+### 8. Bisection harness
+
+`git bisect run` over a script that boots state X, checks the bug,
+exits 0 (good) or 1 (bad).
+
+- **When it fits:** the bug appeared between two known states (commits,
+  package versions, dataset versions); the bug is reproducible at every
+  commit in the range.
+- **Pitfalls:** broken intermediate commits (mark with `git bisect skip`);
+  the bug requires a re-install of dependencies (script must run `pnpm i`);
+  bisecting through a refactor that renamed everything (history-aware
+  bisection — `--first-parent`).
+- **Skeleton:**
+  ```bash
+  #!/usr/bin/env bash
+  set -e
+  pnpm install --frozen-lockfile > /dev/null
+  ./bin/repro || exit 1   # bug present
+  exit 0                   # bug absent
+  ```
+- **Iteration ladder:** cache `node_modules` per commit hash to skip the
+  reinstall; pre-build once if the build is deterministic; bisect over a
+  package-lock range, not source range, when the suspect is a dep.
+
+### 9. Differential loop
+
+Run the same input through two configurations — old version vs new, two
+deployments, two implementations — and diff outputs.
+
+- **When it fits:** "this used to work" bugs where you can run the working
+  version side-by-side; comparing two implementations during a migration;
+  validating a refactor preserves behavior.
+- **Pitfalls:** incidental differences swamp the real one (canonicalize
+  before diffing); the two configurations don't actually receive the same
+  input (log the input on both sides and verify); diff size makes the
+  signal unreadable (semantic diff with `jq -S`).
+- **Skeleton:**
+  ```bash
+  ./bin/old-tool < input.json | jq -S . > /tmp/old.json
+  ./bin/new-tool < input.json | jq -S . > /tmp/new.json
+  diff -u /tmp/old.json /tmp/new.json
+  ```
+- **Iteration ladder:** strip fields known to differ (timestamps, IDs)
+  before diffing; iterate on a curated input corpus, not random inputs;
+  pin both versions to specific hashes so the comparison is reproducible.
+
+### 10. HITL bash
+
+A bash script that prompts a human for the action, captures the result,
+and feeds it back to the agent. Last resort — humans are not part of the
+AFK runner, so this disqualifies the loop as a Tier-1 verifier.
+
+- **When it fits:** the bug is in a closed system (vendor app, hardware,
+  external service) where no programmatic loop exists; the human can give
+  reliable yes/no per iteration.
+- **Pitfalls:** human fatigue (cap iterations); ambiguous answers
+  (force yes/no — no free text); using HITL when one of patterns 1–9
+  would actually have worked.
+- **Skeleton:**
+  ```bash
+  #!/usr/bin/env bash
+  read -p "Click the buy button. Did the modal close? (y/n) " ok
+  [[ "$ok" == "y" ]] && exit 0 || exit 1
+  ```
+- **Iteration ladder:** capture *what* the human did so the next iteration
+  can suggest a programmatic alternative; never use HITL twice in a row
+  without re-evaluating patterns 1–9.
+
+## Which pattern do I pick?
+
+Walk this tree top-to-bottom. Stop at the first "yes."
+
+1. **Is there an existing test seam that exercises the behavior end-to-end?**
+   → Pattern 1 (failing test).
+2. **Is the surface an HTTP API and you have a dev server?** → Pattern 2
+   (curl harness).
+3. **Is the surface a CLI or text transformer?** → Pattern 3 (CLI fixture
+   diff).
+4. **Is the bug only visible in the rendered UI?** → Pattern 4 (headless
+   browser).
+5. **Can you replay a captured production trace?** → Pattern 5 (replay
+   trace).
+6. **Is the system too tangled or mid-refactor to test in place?**
+   → Pattern 6 (throwaway harness).
+7. **Is the bug "sometimes" — non-deterministic on input?** → Pattern 7
+   (property / fuzz).
+8. **Did the bug appear between two known commits / versions?** → Pattern 8
+   (bisection).
+9. **Are there two configurations or versions you can compare?** → Pattern 9
+   (differential).
+10. **Final fallback** — and only after honestly trying 1–9: Pattern 10
+    (HITL bash). Mark the loop as Tier-1-disqualified in any
+    `verification.commands` reference.
+
+If you fall off the bottom of the tree without a fit, the bug isn't
+loopable yet — return to `/linear-triage` and request reproducer access,
+trace capture, or production instrumentation as `needs-info`.
+
+## Iteration ladder
+
+Apply across every pattern. Climb until the loop is fast, sharp, and
+deterministic enough to defend at the relevant tier.
+
+| Step | Cheap | Expensive |
+|---|---|---|
+| Cache setup | Memoize fixture loads, keep dev server warm. | Snapshot the entire DB and restore between runs. |
+| Narrow scope | Filter to one test (`-t name`). | Compile a per-test bundle that excludes unrelated code. |
+| Pin time | Inject a clock; freeze in the test. | Run inside a container with the system clock pinned. |
+| Seed RNG | Pass an explicit seed to test data factories. | Replace global RNG with a deterministic-by-default wrapper. |
+| Isolate filesystem | `tmp.mkdtempSync()` per test. | Per-test ephemeral Supabase branch. |
+| Freeze network | MSW / VCR / nock at the route level. | Container with no egress; recorded HAR replay. |
+| Raise repro rate | Loop the trigger 100×; tighten timing windows. | Inject targeted sleeps to widen the race window; run under TSAN. |
+
+For non-deterministic bugs the goal is not a clean repro but a **higher
+reproduction rate**. A 50%-flake bug is debuggable; 1% is not. Climb the
+ladder until the rate is workable, then build the loop on top of *that*.
+
+## Hand-off — how the loop becomes downstream input
+
+The loop you build here usually doesn't stay in `scripts/debug/`. It
+graduates into the project's permanent infrastructure:
+
+| Caller | What the loop becomes |
+|---|---|
+| [`/diagnose`](../diagnose/SKILL.md) Phase 1 | The active feedback loop for hypothesis testing. The Phase 5 regression test typically condenses it into a permanent test. |
+| [`/tdd`](https://github.com/mattpocock/skills/blob/main/skills/engineering/tdd/SKILL.md) | The first failing test in the red→green cycle. Each subsequent slice extends or copies it. |
+| [`/draft-contract`](../draft-contract/SKILL.md) | A `verification.commands` entry — phrased as a single shell invocation that exits 0 on pass, non-zero on fail. The AFK runner will execute it unattended. |
+| [`/brief-to-contract`](../brief-to-contract/SKILL.md) | The bridge that lifts the loop from "ad-hoc reproducer" to "named verifier in the goal-contract." |
+
+When invoked from `/draft-contract`, output the loop in a form ready to
+paste into `verification.commands`:
+
+```yaml
+verification:
+  commands:
+    - "pnpm vitest run src/cart/total.test.ts -t 'zero-priced item'"
+    # 2.1s wall-clock, deterministic (clock pinned, RNG seeded, MSW for /api/prices)
+```
+
+The trailing comment documents the three-properties evidence so a future
+reader (or auditor) knows what was demonstrated, not just claimed.
+
+## Self-validation before declaring done
+
+- [ ] The loop exits 0 on pass, non-zero on fail. No "look for the right
+      string in the output."
+- [ ] Wall-clock time measured and recorded. (Ideally < 5s, < 2s on Tier
+      1 verifiers.)
+- [ ] The loop has been run **three times in a row** and produced the same
+      result each time.
+- [ ] Every source of non-determinism (time / randomness / filesystem /
+      network) is either neutralized or explicitly documented in a comment.
+- [ ] On Tier 1, no `# flake-budget` comment is present.
+- [ ] No human input required mid-loop (or, if HITL, the disqualification
+      is noted in the hand-off).
+
+If any check fails, fix the loop before returning. A loop that "mostly
+works" is the same as no loop — it pollutes downstream skills with noise.
+
+## Non-goals
+
+- **No test framework prescription.** Use what the project uses. If the
+  project doesn't have one, surface that to the user and let them choose
+  before continuing — picking a framework is a project-level decision,
+  not a per-loop one.
+- **No performance budget setting.** "Loop should be fast" is the
+  discipline here. "API should respond in < 100ms" is a goal-contract
+  field — see [`/draft-contract`](../draft-contract/SKILL.md).
+- **No fix authoring.** This skill ends when the loop reliably observes
+  the bug. The fix is `/diagnose` Phase 5 or `/tdd` green.
+- **No production instrumentation.** Loops live in test code or
+  `scripts/debug/`, never in `src/`. Production probes need explicit user
+  approval per the protected-paths convention.
+- **No CI integration.** Hooking the loop into CI is a project-level
+  decision after the loop is proven locally.
+
+## References
+
+- [`../diagnose/SKILL.md`](../diagnose/SKILL.md) — the primary caller;
+  Phase 1 is "build a loop using this skill."
+- [`../draft-contract/SKILL.md`](../draft-contract/SKILL.md) — consumer
+  for `verification.commands`.
+- [`../brief-to-contract/SKILL.md`](../brief-to-contract/SKILL.md) —
+  orchestrates this skill into the contract pipeline.
+- [Matt Pocock's `/tdd`](https://github.com/mattpocock/skills/blob/main/skills/engineering/tdd/SKILL.md)
+  — the red→green caller; this skill is the "build the red" half.
+- [Matt Pocock's `/diagnose`](https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md)
+  — Phase 1 of his version is the doctrinal source for the ten-pattern
+  catalog; this skill is the expanded reference.
+- `valesco-platform/docs/afk/governance-plan.md` §G10 — Tier-1 verifier
+  determinism rule.
+- `valesco-platform/afk/schemas/goal-contract.v1.json` — the
+  `verification.commands` field shape.


### PR DESCRIPTION
## Summary

- Adds three new flightplan-owned skills — `/diagnose` (six-phase debug discipline), `/feedback-loop` (10-pattern catalog for deterministic agent-runnable signals), and `/brief-to-contract` (orchestration spine with resume detection + HITL exits).
- Adopts Matt Pocock's reorganized `engineering/` bucket: drops deprecated (`domain-model`, `ubiquitous-language`, `design-an-interface`); adds `grill-with-docs`, `to-issues`, `zoom-out`; revives `improve-codebase-architecture` with the updated rationale.
- Establishes `CONTEXT.md` (ubiquitous language) and `docs/adr/` (architectural decisions) as Valesco repo conventions, with `docs/workflow.md` as the new doctrine doc for the end-to-end harness + orchestration flow.

## What's the workflow now?

`/grill-with-docs` → `/to-prd` → `/to-issues` → `/linear-triage` → `/diagnose` (Bugs) → `/draft-contract` → `/attest` → AFK pipeline.

`/brief-to-contract` is the spine that walks a Linear issue through that chain end-to-end with resume detection (15 rules in `state-machine.md`) and clean HITL exits at every stage.

## Authority boundaries

All new skills respect the skills-vs-pipeline rule:
- Never apply `afk-ready` (§G1)
- Never auto-fill `<PLANNER_SUGGESTED:>` tokens (§G8)
- Never rename `.goal-contract.draft.yml` → `.goal-contract.yml` (§G8)
- Never mutate `.afk/attestations/*.json` directly (only `/attest` writes there)
- Never run pre-flight or modify the audit store

Pipeline-level concerns (adversarial pairing, stage-gate enforcer, sequential chain runner, parallel fan-out, and the new Sandcastle-shaped containerized AFK runner) are registered in `docs/gaps.md` as cross-references — they belong in `valesco-platform/afk/`, not here.

## Test plan

- [ ] Read `docs/workflow.md` and confirm the end-to-end map matches the intended flow
- [ ] Confirm the `#contextmd--ubiquitous-language` and `#adrs` anchors referenced from the new skills resolve to the right `docs/workflow.md` headings on GitHub
- [ ] Spot-check governance plan citations (§G1, §G8, §G10, §14.3) against `valesco-platform/docs/afk/governance-plan.md`
- [ ] Walk a real Linear issue through `/brief-to-contract` end-to-end on a Tier-3 project to validate the resume detection
- [ ] Verify the three new skills appear in Claude Code under their slash names after the plugin update lands
- [ ] Confirm the existing `/linear-triage`, `/draft-contract`, `/attest` still trigger correctly (no regressions in their frontmatter triggers)

## Known follow-ups (not in this PR)

- `.claude-plugin/plugin.json` `repository` / `homepage` still reference `ValescoAgency/skills` — should update to `ValescoAgency/flightplan` to match the actual remote. Left out of this PR to keep the namespace stable.
- Linear-native variants of `/to-prd` and `/to-issues` registered in `docs/gaps.md` as future work if Matt's freeform-prose "Other" issue-tracker fallback drifts.
- Sandcastle-shaped containerized AFK runner registered in `docs/gaps.md` as a pipeline (not skill) item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)