### PR TITLE
docs: ADR-0001 tracker adapter contract + CONTEXT.md + refactor plan

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,103 @@
+# CONTEXT.md
+
+Ubiquitous language for the flightplan plugin and the AFK pipeline it
+serves. Terms here are what skills, agents, and humans use to describe the
+domain. Implementation details (file paths, MCP names, framework choices)
+are out of scope — see the relevant `SKILL.md` files for those.
+
+Format follows Matt Pocock's
+[CONTEXT-FORMAT](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/CONTEXT-FORMAT.md).
+Update inline as terms become contested or sharpened during a
+`/grill-with-docs` or `/improve-codebase-architecture` run — don't batch.
+
+---
+
+## Pipeline domain
+
+**AFK** — *Away From Keyboard.* The Valesco autonomous-coding governance
+pipeline that takes an attested goal-contract through pre-flight,
+runner dispatch, validation, and gated promotion. Lives in
+[`valesco-platform/afk/`](https://github.com/ValescoAgency/valesco-platform);
+flightplan skills feed it.
+
+**Goal contract** — a `.goal-contract.yml` at a repo's root specifying
+intent, write paths, budget, success criteria, verifiers, and (Tier 1)
+canary plan. The contract is the agreement between the human and the AFK
+runner; pre-flight rejects malformed or under-specified contracts per §G8.
+
+**Attestation** — the human's act of confirming a goal-contract is ready
+for AFK execution. Produces a record at `.afk/attestations/<id>.json`
+keyed by issue ID and bound to the YAML bytes via SHA-256. The label
+handler refuses to promote on sha drift.
+
+**afk-ready** — the label that triggers pre-flight. Applied by the human,
+never by a skill, after the tier-appropriate delay window (§G1). Its
+application is the last conscious step before pipeline takeover.
+
+**Tier** — `1` / `2` / `3`. Sets the determinism bar, delay window, and
+required artefacts. Tier 1 = production / client-critical (canary plan
+required). Tier 3 = prototype / side project.
+
+**HITL** — *Human In The Loop.* An issue or stage that requires human
+judgment and cannot become an AFK contract. Routed to `ready-for-human`
+rather than coerced toward AFK.
+
+## Tracker domain
+
+**Tracker** — the system where issues, comments, labels, and statuses
+live. For Valesco, that's Linear today; the adapter contract makes it
+swappable. Other supported targets (per the rollout plan): GitHub Issues
+(planned proof-of-concept), Jira (deferred), local markdown (deferred).
+
+**Tracker adapter** — the per-vendor module satisfying a uniform
+operations API for the rest of flightplan to call. Lives at
+`tracker-<provider>/SKILL.md` with a sibling `labels.yml`. Each adapter
+declares its capability set; consumer skills check capabilities before
+using vendor-specific features.
+
+**Active tracker** — the adapter selected at session start by reading
+`.afk/config.yml`'s `tracker:` field. Default `linear` if absent. Missing
+adapter SKILL.md = refuse and surface; no silent fallback.
+
+**Capability set** — the optional features an adapter declares.
+
+- **Floor** (every adapter implements): `fetch_issue`, `list_comments`,
+  `post_comment`, `apply_labels`, `set_status`.
+- **Optional**: `customer_field`, `project_membership`, `cycle_membership`,
+  `team_namespace`, `active_work_detection`.
+
+**Active-work detection** — capability tier (`reliable | best-effort |
+none`) describing how confidently an adapter can identify an issue
+currently being worked on. Linear: reliable (native `In Progress` /
+`In Review`). GitHub: best-effort (linked PR + assignee, or Projects v2).
+Local markdown: none. The `triage` skill gates its read-only-on-active-work
+protection on this capability.
+
+## Process artefacts
+
+**Agent Brief** — the structured comment that tells an AFK runner what to
+build. Format lives in `triage/AGENT-BRIEF.md`; delivery happens via the
+active tracker's `post_comment`. Vendor-agnostic shape; only delivery
+differs per tracker.
+
+**Triage Notes** — the comment posted when an issue moves to `needs-info`.
+Lists what's established and the specific facts required to make the
+issue AFK-ready.
+
+**Out-of-scope KB** — `.out-of-scope/<concept>.md` files in the working
+repo, written when a Feature/Improvement is rejected. Future triage runs
+read these to surface "we already rejected this" matches.
+
+## Canonical state machine
+
+Vocabulary that consumer skills use unchanged across vendors. Adapters
+translate to/from vendor-native names per `tracker-<provider>/labels.yml`,
+with optional per-repo override at `.afk/tracker-labels.yml`.
+
+**State labels**: `needs-triage`, `needs-info`, `ready-for-agent`,
+`ready-for-human`, `wontfix`.
+
+**Category labels**: `Bug`, `Feature`, `Improvement`.
+
+**Status values**: `triage`, `backlog`, `todo`, `in-progress`,
+`in-review`, `done`, `canceled`, `duplicate`.

--- a/docs/adr/0001-tracker-adapter-contract.md
+++ b/docs/adr/0001-tracker-adapter-contract.md
@@ -1,0 +1,160 @@
+# ADR-0001: Tracker adapter contract
+
+- **Status**: Accepted
+- **Date**: 2026-05-01
+- **Deciders**: Jason Kennemer (Valesco) + Claude (design grill)
+- **Format**: based on Matt Pocock's
+  [ADR-FORMAT](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/ADR-FORMAT.md)
+
+## Context
+
+Flightplan's `linear-triage`, `draft-contract`, `brief-to-contract`, and
+`diagnose` skills bind directly to Linear via `mcp__plugin_productivity_linear__*`
+calls. About 70% of `linear-triage/SKILL.md` is in fact vendor-agnostic
+Valesco doctrine (AFK eligibility from `.afk/config.yml`, tier mapping,
+§14.3 control-plane refusals, the canonical state machine, the Agent Brief
+format) — only ~10% is genuinely Linear-specific. The skill *feels*
+Linear-coupled because the table of contents leads with Linear MCP
+operations and uses Linear's status names.
+
+Valesco wants:
+
+1. To use the same triage and contract-drafting machinery against GitHub
+   Issues for low-priority projects (a free-tier alternative).
+2. To eventually support Jira and local-markdown trackers without
+   re-authoring core flightplan logic each time.
+3. The "context layer" — issue body + comments + labels + status — to be
+   a *modular component*, plug-replaceable per repo, while the brief
+   format and AFK doctrine stay shared across all adapters.
+
+The forces:
+
+- Three relevant providers already have first-class MCPs (Linear, GitHub,
+  Atlassian); local markdown does not.
+- Valesco's authority schemas (`goal-contract.v1.json`,
+  `attestation-record.v1.json`) bake in `linearIssueId` as the keying
+  field with a regex `^[A-Z]{2,6}-\d+$`. True vendor neutrality crosses
+  the skills/pipeline boundary.
+- We don't want consumer skills to know which vendor is in use — that
+  defeats the modularity goal.
+
+## Decision
+
+Adopt a four-part contract:
+
+### 1. Skill-per-provider adapter, not MCP-per-provider
+
+Each adapter ships as `tracker-<provider>/SKILL.md` + `labels.yml`. The
+SKILL.md documents which underlying MCP / CLI / file-op handles each
+operation; consumer skills resolve the active adapter at session start
+and follow its operations table.
+
+### 2. Baseline-plus-capabilities operations contract
+
+```
+Floor (every adapter implements):
+  fetch_issue(id)         → { body, status, labels, category, ... }
+  list_comments(id)       → [{ author, body, ts }]
+  post_comment(id, body)  → { id, ts }
+  apply_labels(id, names) → ok
+  set_status(id, name)    → ok
+
+Optional capabilities (declared by the adapter):
+  customer_field
+  project_membership
+  cycle_membership
+  team_namespace
+  active_work_detection: reliable | best-effort | none
+```
+
+Consumer skills query `adapter.capabilities` before using vendor-specific
+features (Tier-1 customer recommendations, active-work read-only checks,
+team-scoped queries).
+
+### 3. Flightplan-canonical labels and statuses with three-layer resolution
+
+Consumer skills speak only canonical names. Adapter ships defaults at
+`tracker-<provider>/labels.yml`. Per-repo overrides land at
+`.afk/tracker-labels.yml` if needed. Non-canonical tracker labels
+(GitHub's `help wanted`, etc.) are preserved on read and untouched on
+write.
+
+### 4. Discovery via existing `.afk/config.yml`
+
+```yaml
+afkEligible: true
+projectTier: 2
+tracker: linear            # default if absent
+trackerLabelsPath: .afk/tracker-labels.yml   # optional
+```
+
+No auto-detection, no fallback chain. Missing adapter = refuse and
+surface.
+
+## Consequences
+
+### Easier
+
+- Adding a new tracker is one new `tracker-<provider>/` directory; no
+  consumer-skill edits required.
+- The same `triage`, `draft-contract`, `brief-to-contract`, `diagnose`
+  skills work against any supported vendor.
+- Future skills can reuse the adapter contract for free.
+- Capability-gated logic means low-richness vendors degrade gracefully
+  rather than failing opaquely.
+
+### Harder
+
+- Consumer skills must maintain capability-check discipline at every
+  vendor-specific use site. Easy to forget.
+- Adapter authors must implement the floor exactly; partial floors
+  silently break consumer skills.
+- The label-mapping layer is a small but real surface to keep correct
+  per vendor.
+
+### Trade-offs vs alternatives
+
+- **MCP-per-provider** (rejected): typed contract is more reliable, but
+  authoring an MCP is heavyweight, the top three vendors already have
+  MCPs we don't own, and local markdown can't reasonably get one.
+  Skill-per-provider gets ~90% of the reliability for ~20% of the cost.
+- **One skill with internal branches** (rejected): defeats reuse —
+  every consumer skill ends up with the same provider-conditional
+  logic.
+- **Matt Pocock's freeform-prose `setup-matt-pocock-skills` pattern**
+  (kept as fallback only): the LLM has to inline-translate "we use Jira"
+  into Jira-specific calls; no real seam. Useful as the soft fallback
+  when no adapter SKILL.md exists, not as the primary mechanism.
+
+### Phase B blocker (acknowledged)
+
+The `linearIssueId` field name and `^[A-Z]{2,6}-\d+$` regex live in
+`valesco-platform`'s authority schemas. This contract does **not**
+resolve them. GitHub-issue contracts will fail schema validation at
+`/draft-contract` until a separate v2 migration in valesco-platform
+renames the field to `trackerIssueId` and broadens the regex. The GitHub
+adapter still works fully through `/triage` independently of that
+migration.
+
+## Status
+
+Accepted. Implementation ships in two phases:
+
+- **PR A1** — rename `linear-triage` → `triage`, author `tracker-linear`,
+  refactor consumer skills, update docs, register the schema-migration
+  blocker.
+- **PR A2** — `tracker-github` proof-of-concept (follow-up).
+
+Schema migration in `valesco-platform` is a separate ticket gated by
+real demand for full vendor neutrality.
+
+## References
+
+- [`/Users/jkennemer/Developer/flightplan/CONTEXT.md`](../../CONTEXT.md)
+  — ubiquitous language including all terms used here.
+- [`docs/refactor-plan.md`](../refactor-plan.md) — phased PR roadmap.
+- `valesco-platform/docs/afk/governance-plan.md` §G8 (planner→main token
+  gate), §G10 (Tier-1 canary), §14.3 (control-plane self-modification
+  refusal).
+- [Matt Pocock's `/setup-matt-pocock-skills`](https://github.com/mattpocock/skills/blob/main/skills/engineering/setup-matt-pocock-skills/SKILL.md)
+  — the fallback pattern this contract supersedes for Valesco repos.

--- a/docs/refactor-plan.md
+++ b/docs/refactor-plan.md
@@ -1,0 +1,162 @@
+# Refactor plan — tracker adapter rollout
+
+Phased roadmap for landing [ADR-0001](./adr/0001-tracker-adapter-contract.md).
+Goal: extract the issue-tracker context layer into a modular `tracker-<provider>/`
+component so flightplan's core skills (triage, contract drafting,
+diagnosis, orchestration) work unchanged across Linear, GitHub Issues,
+and future vendors.
+
+## Phases at a glance
+
+| Phase | Repo | Scope | Depends on | Status |
+|---|---|---|---|---|
+| **A1** | flightplan | Rename + Linear adapter extraction + ADR + CONTEXT.md | nothing | next |
+| **A2** | flightplan | `tracker-github` proof-of-concept (triage-only end-to-end) | A1 | follow-up |
+| **B** | valesco-platform | Schema v2: `linearIssueId` → `trackerIssueId`, regex broadening, label-handler update | independent of A | when GitHub AFK chain is real demand |
+| **A3** | flightplan | Skill sweep to use `trackerIssueId` (post-Phase B) | A1, B | post-B |
+
+A1 and B can run in parallel. A2 depends on A1. A3 depends on both.
+
+---
+
+## Phase A1 — Rename + Linear adapter
+
+**Branch**: `feature/tracker-adapter`
+
+**Ships**:
+
+- Rename `linear-triage/` → `triage/`. Refactor `triage/SKILL.md` to
+  speak adapter-canonical names (no Linear MCP calls inline).
+- `tracker-linear/SKILL.md` — operations table mapping each contract
+  operation to the underlying Linear MCP call. Capability declaration
+  block.
+- `tracker-linear/labels.yml` — identity mapping (Valesco repos already
+  use canonical names directly).
+- Migrate Linear-specific knowledge from `triage` into `tracker-linear`:
+  the VA / MREG / FMF team table, status-name translation, the
+  Linear-MCP cheatsheet.
+- Refactor consumer skills (`draft-contract`, `brief-to-contract`,
+  `diagnose`) to call "the active tracker adapter" via the operations
+  table rather than `mcp__plugin_productivity_linear__*` directly.
+- New `.afk/config.yml` field documented: `tracker: linear` (default).
+- Doc updates:
+  - `docs/workflow.md` — new section on the adapter contract.
+  - `docs/starter-set.md` — drop Matt's `/triage` from adopted with
+    rationale (Valesco's is a strict superset).
+  - `docs/gaps.md` — close `/triage` rename gap; register Phase B and
+    Phase A2.
+  - `README.md` — skills table updated.
+  - `.claude-plugin/plugin.json` — bump to `0.3.0`; updated description
+    + keywords.
+
+**Backwards compatibility**:
+
+- Existing `.afk/config.yml` files without `tracker:` continue to work
+  (default `linear`).
+- Existing consumer-skill behavior is unchanged for Linear-backed repos.
+- The slash command rename (`/linear-triage` → `/triage`) is a breaking
+  change. Plugin namespace prefix (`valesco:triage`) makes the canonical
+  invocation unambiguous; bare `/triage` resolves to ours since Matt's
+  is dropped from the adopted set.
+
+**Out of scope for A1** (registered for follow-up):
+
+- Authoring the GitHub adapter (Phase A2).
+- Schema migration in valesco-platform (Phase B).
+- Tooling to validate adapter conformance (future, only if needed).
+
+---
+
+## Phase A2 — `tracker-github` proof-of-concept
+
+**Branch**: `feature/tracker-github`
+
+**Ships**:
+
+- `tracker-github/SKILL.md` — operations table mapping to `gh` CLI or
+  the GitHub MCP (whichever is connected). Capability declaration with
+  explicit `customer_field: false`, `team_namespace: false`,
+  `active_work_detection: best-effort`.
+- `tracker-github/labels.yml` — vendor default mapping
+  (`bug`→`Bug`, `enhancement`→`Feature`, `documentation`→`Improvement`,
+  etc.).
+- Walk one real low-priority GitHub-Issues repo through `/triage`
+  end-to-end as the validation milestone.
+- Doc updates: starter-set, gaps register, workflow.md.
+
+**Known constraint** (acknowledged, documented):
+
+- The full chain `/triage` → `/draft-contract` → `/attest` will reject
+  GitHub issue IDs at schema validation until Phase B lands. The
+  `tracker-github/SKILL.md` calls this out explicitly so users don't
+  hit the wall unprepared.
+
+---
+
+## Phase B — Schema v2 in `valesco-platform`
+
+**Repo**: `valesco-platform`. **Branch**: TBD when the work starts.
+
+**Ships**:
+
+- `goal-contract.v2.json` — `metadata.linearIssueId` → `metadata.trackerIssueId`;
+  regex broadened to accept GitHub-style `owner/repo#NNN`.
+- `attestation-record.v2.json` — same field rename + regex.
+- Label handler update — read v2 schema; key attestation lookup by
+  `trackerIssueId`.
+- Pre-flight update — read v2 schema; surface the field rename in error
+  messages.
+- Migration for in-flight records:
+  - Existing `.goal-contract.yml` files: schema validators accept both
+    v1 and v2 during a transition window; PR template prompts maintainers
+    to bump.
+  - Existing `.afk/attestations/*.json`: filename pattern is unchanged
+    (still keyed by issue ID); contents get a one-line transform script.
+- Own attestation walk — this is governance-grade; use `/attest` against
+  a meta-contract authored for the migration itself per §G1.
+
+**Triggering condition**: real demand for AFK chains on non-Linear
+repos. Don't ship preemptively — the migration cost is real, and it's
+governance-bound.
+
+---
+
+## Phase A3 — Skill sweep post-Phase B
+
+**Branch**: `chore/trackerIssueId-sweep`
+
+**Ships**:
+
+- Search-and-replace across flightplan skills: `linearIssueId` →
+  `trackerIssueId` in prose, examples, regex references, and the
+  `attest` filename pattern.
+- Ensure attestation records keyed by `trackerIssueId` are read/written
+  correctly in `attest/SKILL.md`.
+- Update `state-machine.md` rules in `brief-to-contract/` to reference
+  the new field name in detection rules.
+- Doc updates removing the Phase B blocker mentions.
+
+**Out of scope**:
+
+- Anything that wasn't already in scope for A1 or A2 — this is purely a
+  field-rename sweep.
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Capability checks forgotten in consumer skills, leading to vendor-specific assumptions creeping back in | A1 includes an explicit capability-check pattern in each consumer skill; review checklist in PR description. |
+| Adapter prose drifts from operations contract over time | ADR-0001 is canonical; adapters reference back to it. Schema-typed contract (Option 2 from grilling) remains a future option if drift becomes a problem. |
+| Phase B never happens, A2 ships and confuses users at the `draft-contract` step | A2's `tracker-github/SKILL.md` documents the Phase B blocker explicitly; `/draft-contract` error message points at the gap. |
+| Slash-command rename `/linear-triage` → `/triage` breaks user muscle memory | Plugin version bump (0.2.0 → 0.3.0) signals breaking change; README + starter-set call out the rename; `/linear-triage` removal is documented. |
+
+## References
+
+- [ADR-0001: Tracker adapter contract](./adr/0001-tracker-adapter-contract.md)
+  — the design decision this plan implements.
+- [`CONTEXT.md`](../CONTEXT.md) — ubiquitous language including all
+  terms used in this plan.
+- `valesco-platform/docs/afk/governance-plan.md` — pipeline-side
+  governance that constrains Phase B.


### PR DESCRIPTION
## Summary

Doc-only PR capturing the design decisions from a `/grill-with-docs`-style session on extracting the issue-tracker context layer into a modular `tracker-<provider>/` component. Implementation lands in a separate PR (`feature/tracker-adapter`) following this one.

Three artefacts:

- **`CONTEXT.md`** — first ubiquitous-language entries for the flightplan repo. Covers pipeline domain (AFK, goal contract, attestation, afk-ready, tier, HITL), tracker domain (tracker, adapter, active tracker, capability set, active-work detection), process artefacts (Agent Brief, Triage Notes, OOS KB), and the canonical state machine.
- **`docs/adr/0001-tracker-adapter-contract.md`** — design decision in MADR-ish format. Four-part contract: skill-per-provider adapter (not MCP-per-provider), baseline-plus-capabilities operations contract, flightplan-canonical labels with three-layer resolution, `.afk/config.yml`-based discovery.
- **`docs/refactor-plan.md`** — four-phase rollout (A1 rename + Linear adapter, A2 GitHub adapter PoC, B schema v2 in valesco-platform, A3 sweep post-B) with risk register.

## Why doc-only PR first

The design decisions are fresh; six months from now the rationale for choosing skill-per-provider over MCP-per-provider will fade. Capturing them now in their own PR keeps the design history clean and independent of implementation pacing.

## Phase B is acknowledged, not solved

The `linearIssueId` field name + `^[A-Z]{2,6}-\d+$` regex live in `valesco-platform`'s authority schemas. This contract does not resolve them — that's separate pipeline work registered in the refactor plan as Phase B. The GitHub adapter (Phase A2) ships through `/triage` independently of Phase B; only the full chain through `/draft-contract` waits on the schema migration.

## Test plan

- [ ] Read [`CONTEXT.md`](CONTEXT.md) and confirm terms match how the team actually talks about the domain
- [ ] Read [ADR-0001](docs/adr/0001-tracker-adapter-contract.md) and confirm the recommendation captures the grilling outcome accurately
- [ ] Read [refactor plan](docs/refactor-plan.md) and confirm the phasing matches expectations (A1 next, A2 follow-up, B when GitHub demand is real, A3 post-B)
- [ ] Verify no skill cross-references to these new files break (none expected — these files are referenced *by* the upcoming PR A1, not by anything on `main` today)

## What's next

PR A1 (`feature/tracker-adapter`) — same author, same session — implements the contract: rename `linear-triage` → `triage`, author `tracker-linear`, refactor consumer skills, update workflow doc and gaps register, bump plugin version. That PR will reference this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)