### PR TITLE
chore: dogfood tracker-github via flightplan's own .afk/config.yml

### DIFF
--- a/.afk/config.yml
+++ b/.afk/config.yml
@@ -1,0 +1,28 @@
+# Flightplan repo's own AFK configuration.
+#
+# This is the meta-plugin: it ships the skills that drive AFK runs on
+# OTHER Valesco repos. By the same governance reasoning that applies to
+# valesco-platform (§14.3 — control planes cannot rewrite their own
+# policies), this repo is afkEligible: false. AFK contracts that could
+# rewrite /triage or /attest themselves would create a governance
+# self-modification loop.
+#
+# What this means in practice:
+#   - All actionable issues route to ready-for-human, never ready-for-agent
+#   - /draft-contract refuses (no Tier-1/2/3 contract path)
+#   - /triage works fully — issue funnel + Agent Brief / Human Brief comments
+#   - /diagnose, /feedback-loop, Matt's grilling skills all work normally
+#
+# This config also serves as the dogfood validation milestone for the
+# tracker-github adapter (Phase A2). Walking a real flightplan issue
+# through /triage end-to-end against GitHub Issues is the proof that the
+# adapter contract holds beyond Linear.
+
+afkEligible: false        # This repo is a skill-layer control plane
+projectTier: 2            # Internal tooling; informational while afkEligible:false
+tracker: github           # Use the tracker-github adapter (Phase A2)
+
+# trackerLabelsPath:      # Uncomment + populate if this repo's GitHub
+#                         # labels diverge from tracker-github/labels.yml
+#                         # defaults. Today they don't — the repo will
+#                         # use the adapter defaults verbatim.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "valesco",
-  "version": "0.3.0",
-  "description": "Valesco-authored Claude Code skills for harness engineering and agent orchestration around the AFK autonomous-coding governance pipeline. Vendor-agnostic via the tracker adapter contract — Linear adapter ships by default; GitHub Issues, Jira, and local-markdown adapters planned. Bundles the orchestration spine (/brief-to-contract), harness skills (/diagnose, /feedback-loop), tracker funnel (/triage), goal-contract drafting (/draft-contract), and tier-scaled attestation (/attest). User-invoked, advisory skills only — pipeline code (validators, pre-flight, audit, label handler) lives in valesco-platform per the skills-vs-pipeline rule.",
+  "version": "0.4.0",
+  "description": "Valesco-authored Claude Code skills for harness engineering and agent orchestration around the AFK autonomous-coding governance pipeline. Vendor-agnostic via the tracker adapter contract — ships with Linear (full capability) and GitHub Issues (proof-of-concept; reduced capability) adapters; Jira and local-markdown adapters deferred. Bundles the orchestration spine (/brief-to-contract), harness skills (/diagnose, /feedback-loop), tracker funnel (/triage), goal-contract drafting (/draft-contract), and tier-scaled attestation (/attest). User-invoked, advisory skills only — pipeline code (validators, pre-flight, audit, label handler) lives in valesco-platform per the skills-vs-pipeline rule.",
   "author": {
     "name": "Valesco Agency",
     "email": "jason@valescoagency.com",
@@ -19,6 +19,7 @@
     "agent-orchestration",
     "tracker-adapter",
     "linear",
+    "github",
     "triage",
     "diagnose",
     "feedback-loop",

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ active adapter is selected via `tracker:` in `.afk/config.yml` (default
 | Adapter | Status | Capabilities |
 |---|---|---|
 | [`tracker-linear`](tracker-linear/SKILL.md) | Shipped (default) | Full — customer field, project/cycle membership, team namespace, reliable active-work detection |
-| `tracker-github` | Planned (Phase A2) | Reduced — no customer field, best-effort active-work detection. Triage works end-to-end; full chain through `/draft-contract` waits on Phase B schema migration in `valesco-platform`. |
+| [`tracker-github`](tracker-github/SKILL.md) | Shipped (Phase A2) | Reduced — no customer field, best-effort active-work detection. Triage works end-to-end; full chain through `/draft-contract` waits on Phase B schema migration in `valesco-platform`. |
 | `tracker-jira`, `tracker-local-md` | Deferred | — |
 
 These compose with Matt Pocock's

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ active adapter is selected via `tracker:` in `.afk/config.yml` (default
 | [`tracker-github`](tracker-github/SKILL.md) | Shipped (Phase A2) | Reduced — no customer field, best-effort active-work detection. Triage works end-to-end; full chain through `/draft-contract` waits on Phase B schema migration in `valesco-platform`. |
 | `tracker-jira`, `tracker-local-md` | Deferred | — |
 
+This repo is its own dogfood for the GitHub adapter — see
+[`.afk/config.yml`](.afk/config.yml). `afkEligible: false` (skill-layer
+control plane); `tracker: github`. Walking flightplan issues through
+`/triage` against the `tracker-github` adapter is the validation
+milestone for Phase A2.
+
 These compose with Matt Pocock's
 [engineering skills](https://github.com/mattpocock/skills/tree/main/skills/engineering)
 (`/grill-with-docs`, `/to-prd`, `/to-issues`,

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -43,22 +43,6 @@ Each entry:
 - **Classification**: skill.
 - **Tracking**: none yet.
 
-### `tracker-github` adapter (Phase A2)
-
-- **Purpose**: GitHub Issues adapter implementing the
-  [tracker contract](./adr/0001-tracker-adapter-contract.md). Free
-  alternative for low-priority projects. Reduced capabilities — no
-  `customer_field`, `team_namespace: false`,
-  `active_work_detection: best-effort`.
-- **Trigger-to-author**: When a real low-priority project needs
-  `/triage` against GitHub Issues. Don't ship preemptively.
-- **Classification**: skill.
-- **Tracking**: none yet. See
-  [`refactor-plan.md`](./refactor-plan.md#phase-a2--tracker-github-proof-of-concept).
-- **Constraint**: full chain (`/draft-contract` and downstream) blocks
-  on Phase B schema migration in `valesco-platform`. Triage works
-  end-to-end independently.
-
 ### `tracker-jira` and `tracker-local-md` adapters
 
 - **Purpose**: Same contract; cover Jira workflows and local-markdown
@@ -139,6 +123,32 @@ belong in `valesco-platform/afk/`.
 ---
 
 ## Closed gaps
+
+### `tracker-github` adapter (Phase A2) — shipped 2026-05-01
+
+- **Ships**: `tracker-github/SKILL.md`, `tracker-github/labels.yml`.
+- **Purpose**: GitHub Issues adapter — proof-of-concept and
+  free-alternative for low-priority projects. Implements the floor
+  (`fetch_issue`, `list_comments`, `post_comment`, `apply_labels`,
+  `set_status`) via the `gh` CLI. Capability declaration:
+  `customer_field: false`, `project_membership: false`,
+  `cycle_membership: false`, `team_namespace: false`,
+  `active_work_detection: best-effort`.
+- **Status mapping**: GitHub has no native status enum; the adapter
+  encodes canonical statuses via issue `state` + `stateReason` + a
+  single mutually-exclusive state-encoding label
+  (`triage`/`backlog`/`todo`/`in-progress`/`in-review`/`reviewed`).
+- **Active-work detection**: heuristic — open issue + (linked PR via
+  timeline OR has assignee). `/triage` warns but doesn't refuse on
+  best-effort detection.
+- **Constraint** (still open): the full AFK chain through
+  `/draft-contract` and downstream rejects GitHub-shaped IDs
+  (`owner/repo#NNN`) at schema validation. `/triage` works
+  end-to-end against GitHub today; the rest waits on Phase B.
+- **Validation milestone**: walk one real low-priority GitHub-Issues
+  repo through `/triage` end-to-end before declaring this
+  battle-tested. The `flightplan` repo itself is a fine first
+  candidate.
 
 ### Tracker adapter contract — shipped 2026-05-01
 

--- a/docs/starter-set.md
+++ b/docs/starter-set.md
@@ -36,7 +36,7 @@ Loaded automatically by consumer skills based on `.afk/config.yml`'s
 | Adapter | Status | Notes |
 |---|---|---|
 | [`tracker-linear`](../tracker-linear/SKILL.md) | Shipped (default) | Full capability set. |
-| `tracker-github` | Planned (Phase A2) | Triage end-to-end works; full chain blocks on Phase B schema migration. |
+| [`tracker-github`](../tracker-github/SKILL.md) | Shipped (Phase A2) | Triage end-to-end works; full chain blocks on Phase B schema migration. |
 | `tracker-jira`, `tracker-local-md` | Deferred | — |
 
 ---

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -112,7 +112,7 @@ only canonical names; the adapter translates to vendor-native form.
 | Adapter | Status | Notes |
 |---|---|---|
 | [`tracker-linear`](../tracker-linear/SKILL.md) | Default, shipped | Full capability set — `customer_field`, `team_namespace`, reliable active-work detection. |
-| `tracker-github` | Planned (Phase A2) | Triage-end-to-end works; full chain through `/draft-contract` blocked on Phase B schema migration in `valesco-platform`. |
+| [`tracker-github`](../tracker-github/SKILL.md) | Shipped (Phase A2) | Triage-end-to-end works; full chain through `/draft-contract` blocked on Phase B schema migration in `valesco-platform`. |
 | `tracker-jira`, `tracker-local-md` | Deferred | — |
 
 The contract that defines the adapter API is

--- a/tracker-github/SKILL.md
+++ b/tracker-github/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: tracker-github
+description: GitHub Issues adapter for flightplan's tracker contract. Implements the canonical operations API (`fetch_issue`, `list_comments`, `post_comment`, `apply_labels`, `set_status`) using the `gh` CLI (or the GitHub MCP if loaded). Loaded by consumer skills (`/triage`, `/draft-contract`, `/brief-to-contract`, `/diagnose`) when `.afk/config.yml` declares `tracker: github`. Not invoked directly by users — this is the adapter the rest of flightplan reads from. Suitable for low-priority projects that don't justify a Linear seat; the full AFK chain through `/draft-contract` is blocked on Phase B schema migration in `valesco-platform`, but `/triage` works end-to-end against GitHub today.
+disable-model-invocation: true
+---
+
+# tracker-github — GitHub Issues adapter
+
+Implements the [tracker adapter contract](../docs/adr/0001-tracker-adapter-contract.md)
+for [GitHub Issues](https://docs.github.com/en/issues). Consumer skills
+load this adapter when `.afk/config.yml` declares `tracker: github`.
+
+GitHub operations go through the [`gh` CLI](https://cli.github.com/) by
+default. If the [GitHub MCP](https://github.com/github/github-mcp-server)
+is loaded in the session (`mcp__plugin_engineering_github__*`), prefer
+its typed calls — they're faster and better-typed than `gh` for bulk
+queries. Use `gh` as the universal floor.
+
+## Phase B blocker — read this first
+
+Until `valesco-platform`'s schema v2 migration lands, the full AFK
+chain through `/draft-contract` and `/attest` will reject GitHub issue
+IDs at schema validation. The contract field `metadata.linearIssueId`
+has regex `^[A-Z]{2,6}-\d+$` — GitHub's `owner/repo#NNN` doesn't
+match.
+
+What works today against GitHub:
+
+- `/triage` end-to-end (label/status transitions, Agent Brief
+  comments, OOS knowledge base, the full triage funnel)
+- `/diagnose` end-to-end (no schema dependencies)
+- `/feedback-loop` (no tracker dependencies)
+
+What does **not** work until Phase B lands:
+
+- `/draft-contract` (rejects the GitHub-shaped ID at schema validation)
+- `/attest` (depends on the contract being valid)
+- `/brief-to-contract` (orchestrates the above; will halt at the draft
+  step)
+
+The constraint is intentional and registered in
+[`docs/refactor-plan.md`](../docs/refactor-plan.md). Phase A1 (rename
++ adapter contract) and Phase A2 (this adapter) ship independently of
+Phase B; the GitHub AFK chain becomes complete only when Phase B does.
+
+## Capability declaration
+
+```yaml
+capabilities:
+  customer_field: false              # GH issues have no customer concept
+  project_membership: false          # GH Projects v2 exists but requires
+                                     # GraphQL; treat as out-of-scope here.
+                                     # Per-repo override may flip this true
+                                     # if the repo standardizes on Projects v2.
+  cycle_membership: false            # GH milestones are coarser, not equivalent
+  team_namespace: false              # GH is org-scoped; no first-class team concept
+  active_work_detection: best-effort # open + linked PR + assignee, heuristic only
+```
+
+Consumer-skill consequences:
+
+- `/triage` will not recommend Tier 1 from GitHub-issue inputs
+  (`customer_field: false`). Tier 1 escalation in `/brief-to-contract`
+  must come from `.afk/config.yml`'s `projectTier: 1` explicitly.
+- `/triage`'s read-only-on-active-work protection **warns instead of
+  refusing** when about to mutate an issue that *might* be in active
+  work — there's no reliable signal, only heuristics.
+- Project-scoped or cycle-scoped queue views in `/triage` are
+  unavailable.
+
+## ID format
+
+GitHub issue references take any of these forms:
+
+- `<num>` — e.g., `42`. Implicit repo, derived from
+  `git remote get-url origin` (must be a `github.com` remote).
+- `#<num>` — e.g., `#42`. Same as above.
+- `<owner>/<repo>#<num>` — e.g., `ValescoAgency/flightplan#42`.
+  Explicit. Use this form when posting cross-repo references.
+
+The adapter normalizes incoming references to canonical
+`<owner>/<repo>#<num>` form for all subsequent operations. If repo
+inference fails (no GitHub remote, ambiguous remote), surface the
+failure rather than guessing.
+
+## Operations table
+
+The contract floor every adapter must implement.
+
+| Canonical operation | `gh` CLI | Notes |
+|---|---|---|
+| `fetch_issue(id)` | `gh issue view <num> --repo <owner/repo> --json number,title,body,state,stateReason,labels,assignees,milestone,projectItems,createdAt,updatedAt,closedAt,url` | Map to canonical shape: status from `state` + `stateReason` + state-encoding labels (see [Status mapping](#status-mapping)); category + state labels via [`labels.yml`](./labels.yml); preserve unknown labels as `extra_labels`. |
+| `list_comments(id)` | `gh issue view <num> --repo <owner/repo> --json comments` | Return each comment with `author.login`, `body`, ISO `createdAt`. |
+| `post_comment(id, body)` | `gh issue comment <num> --repo <owner/repo> --body-file -` (pipe body in) | Markdown is supported. Body is passed verbatim — disclaimer is the consumer's responsibility. |
+| `apply_labels(id, names)` | `gh issue edit <num> --repo <owner/repo> --add-label <name1> [--add-label <nameN>]` | Resolve canonical names → GitHub label strings via [`labels.yml`](./labels.yml). For removals (e.g., when transitioning state), use `--remove-label`. |
+| `set_status(id, name)` | composite — see [Status mapping](#status-mapping) | GitHub has no status enum; encode via state + state-encoding label. |
+
+Optional operations:
+
+| Canonical operation | Implementation | Capability flag |
+|---|---|---|
+| `is_active_work(id)` | Best-effort: returns true if issue is open AND (has linked PR via `gh issue view --json closingIssuesReferences,timelineItems` OR has at least one assignee). | `active_work_detection: best-effort` |
+| `list_repo_issues(state, labels, ...)` | `gh issue list --repo <owner/repo> --state <s> --label <l> --json ...` | (always available — no capability flag) |
+
+## Status mapping
+
+GitHub doesn't have a native status enum. The adapter encodes the
+canonical state machine using `state` + `stateReason` + a single
+**state-encoding label** (mutually exclusive with other state-encoding
+labels).
+
+State-encoding labels are: `triage`, `backlog`, `todo`, `in-progress`,
+`in-review`, `reviewed`. Read these via `labels.yml` so per-repo
+overrides apply.
+
+| Canonical | GitHub `state` | `stateReason` | State-encoding label |
+|---|---|---|---|
+| `triage` | `OPEN` | — | `triage` |
+| `backlog` | `OPEN` | — | `backlog` |
+| `todo` | `OPEN` | — | `todo` |
+| `in-progress` | `OPEN` | — | `in-progress` |
+| `in-review` | `OPEN` | — | `in-review` |
+| `reviewed` | `OPEN` | — | `reviewed` |
+| `done` | `CLOSED` | `COMPLETED` | (none) |
+| `canceled` | `CLOSED` | `NOT_PLANNED` | (none) |
+| `duplicate` | `CLOSED` | `DUPLICATE` | (none) |
+
+`set_status` semantics:
+
+- For an OPEN canonical status: ensure issue is open (`gh issue
+  reopen` if currently closed), apply the new state-encoding label,
+  remove any other state-encoding labels.
+- For a CLOSED canonical status: `gh issue close --reason
+  <state_reason>` (the `gh` flag accepts `completed`, `not planned`,
+  or `duplicate`). State-encoding labels are not stripped on close —
+  they record the last open status, which is fine.
+- `duplicate`: GitHub supports `--reason "duplicate"`. When
+  transitioning to duplicate, the consumer skill should also post a
+  comment linking the canonical issue *before* calling `set_status`.
+
+`fetch_issue` reverse mapping:
+
+- If `state == OPEN`, find the first state-encoding label present
+  (priority: `in-review`, `reviewed`, `in-progress`, `todo`, `backlog`,
+  `triage`). If none, default to `triage`.
+- If `state == CLOSED`, map `stateReason` → canonical: `COMPLETED`
+  → `done`, `NOT_PLANNED` → `canceled`, `DUPLICATE` → `duplicate`.
+  Treat unknown / null `stateReason` as `done`.
+
+## Active-work detection (best-effort)
+
+GitHub provides no first-class signal for "this is being actively
+worked on." The adapter offers a heuristic:
+
+```
+is_active_work(id) → true if ALL:
+  - state == OPEN
+  - (has linked PR via timelineItems[].source resolving to a PR
+     that's not yet closed/merged)
+    OR
+    (has at least one assignee)
+```
+
+This is **best-effort** — it will miss a contributor who's working in
+a fork without a draft PR yet, and it will false-positive on stale
+assignees. `/triage`'s read-only protection treats `best-effort` as
+"warn, don't refuse" — the maintainer makes the call.
+
+For repos that standardize on GitHub Projects v2, a per-repo override
+in `.afk/tracker-labels.yml` can declare a richer detection rule
+(e.g., "active means Projects v2 status field is `In Progress`").
+Out of scope for this adapter; treat Projects v2 as orthogonal.
+
+## Label mapping
+
+See [`labels.yml`](./labels.yml). GitHub repos commonly use lowercase
+labels (`bug`, `enhancement`, `documentation`) where canonical uses
+capitalized categories (`Bug`, `Feature`, `Improvement`). Per-repo
+overrides via `.afk/tracker-labels.yml` follow the three-layer
+resolution rule from [ADR-0001](../docs/adr/0001-tracker-adapter-contract.md).
+
+**Non-canonical labels** (e.g., `good first issue`, `help wanted`,
+`priority:high`) are **preserved on read** as `extra_labels` and
+**untouched on write**. The adapter never strips a community's
+labeling convention.
+
+## Required `gh` setup
+
+The adapter assumes:
+
+- `gh` CLI is installed (`gh --version` works).
+- The user is authenticated (`gh auth status` shows logged-in for
+  github.com).
+- The active repo's remote is reachable (`gh repo view` succeeds).
+- The user has write access to the repo if mutating operations
+  (`apply_labels`, `set_status`, `post_comment`) will be called.
+
+If any precondition fails, refuse and surface the failure. Don't fall
+back silently to read-only mode.
+
+## `gh` CLI cheatsheet
+
+| Need | Command |
+|---|---|
+| One issue (full) | `gh issue view <num> --repo <r> --json number,title,body,state,stateReason,labels,assignees,milestone,createdAt,updatedAt,closedAt,url` |
+| One issue (with comments + timeline) | `gh issue view <num> --repo <r> --json ...,comments,timelineItems` |
+| List repo issues | `gh issue list --repo <r> --state <open\|closed\|all> --label <l> --limit <n>` |
+| Comment | `gh issue comment <num> --repo <r> --body-file -` (then pipe body) |
+| Add labels | `gh issue edit <num> --repo <r> --add-label <a> --add-label <b>` |
+| Remove labels | `gh issue edit <num> --repo <r> --remove-label <a>` |
+| Close (done) | `gh issue close <num> --repo <r> --reason completed` |
+| Close (canceled) | `gh issue close <num> --repo <r> --reason "not planned"` |
+| Close (duplicate) | `gh issue close <num> --repo <r> --reason duplicate` |
+| Reopen | `gh issue reopen <num> --repo <r>` |
+| List repo labels | `gh label list --repo <r>` |
+
+When in doubt about a flag, run `gh issue --help` or
+`gh issue <subcommand> --help` rather than guessing.
+
+## Self-validation checks
+
+The adapter guarantees these to consumer skills. If a downstream skill
+catches a violation, file a bug against this adapter.
+
+- `fetch_issue` returns canonical status names (mapped through the
+  table above), never raw `OPEN`/`CLOSED` strings.
+- `list_comments` returns timestamps as ISO 8601, regardless of `gh`'s
+  output shape (`gh` does ISO 8601 already, but the adapter normalizes
+  on the off chance the format changes).
+- `apply_labels` only modifies labels that map to canonical names plus
+  the state-encoding labels enumerated in the status mapping table.
+  Non-canonical labels are preserved on read and untouched on write.
+- `set_status("triage")` always lands the issue in OPEN state with
+  the `triage` state-encoding label, never just labels alone (state
+  must be coherent).
+- ID format normalization always returns `<owner>/<repo>#<num>` form
+  before performing operations, even if the input was bare `<num>`.
+
+## What this adapter does NOT do
+
+- **No goal-contract knowledge.** The schema field
+  `metadata.linearIssueId` (its name unchanged in this rollout)
+  belongs to consumer skills and to `valesco-platform`'s schemas.
+  This adapter just provides the issue ID; the GitHub-shaped ID will
+  fail the existing regex until Phase B.
+- **No tier inference from GitHub metadata.** Tier comes from
+  `.afk/config.yml`. (`projectTier: 1` repos using GitHub will
+  trigger Tier 1 even though GitHub has no `customer_field` —
+  `/brief-to-contract` will surface that the customer must come from
+  another source, e.g., the `.afk/config.yml` declaration.)
+- **No AFK-eligibility decisions.** Eligibility is consumer-side.
+- **No PR creation or branch operations.** This adapter only touches
+  Issues. Pull-request work is out of scope.
+- **No GitHub Projects v2 integration.** Treat as orthogonal; revisit
+  if a Valesco repo standardizes on it.
+- **No GitLab support.** That's a separate adapter (`tracker-gitlab`,
+  not currently planned).
+
+## References
+
+- [`../docs/adr/0001-tracker-adapter-contract.md`](../docs/adr/0001-tracker-adapter-contract.md)
+  — the design decision this adapter implements.
+- [`../docs/refactor-plan.md`](../docs/refactor-plan.md) — Phase A2
+  scope (this adapter); Phase B (schema migration that unblocks the
+  full chain).
+- [`./labels.yml`](./labels.yml) — label mapping for GitHub.
+- [`../tracker-linear/SKILL.md`](../tracker-linear/SKILL.md) — sibling
+  adapter (full-capability reference implementation).
+- [`../CONTEXT.md`](../CONTEXT.md) — canonical state machine and
+  capability set.
+- [`gh` CLI manual](https://cli.github.com/manual/) — for any
+  operation the cheatsheet doesn't cover.
+- [GitHub Issues REST API](https://docs.github.com/en/rest/issues)
+  and [GraphQL API](https://docs.github.com/en/graphql) — underlying
+  surfaces; rarely needed directly when `gh` covers the operation.

--- a/tracker-github/labels.yml
+++ b/tracker-github/labels.yml
@@ -1,0 +1,81 @@
+# GitHub Issues adapter — default label mapping.
+#
+# Format: <canonical name>: <vendor-native string>
+#
+# GitHub's community-standard labels are lowercase and slightly
+# different from Valesco's canonical names. This file maps both ways.
+# Per-repo overrides land at `.afk/tracker-labels.yml` if a specific
+# repo uses different strings (e.g., `bug:prod` instead of `bug`).
+#
+# See ../docs/adr/0001-tracker-adapter-contract.md for the three-layer
+# resolution rule (canonical → adapter default → per-repo override).
+
+# Category labels — every actively-triaged issue has exactly one.
+# GitHub's `bug` and `enhancement` labels exist by default on most
+# repos; `improvement` is non-standard and will be created by the
+# adapter on first use if absent.
+categories:
+  Bug: bug
+  Feature: enhancement
+  Improvement: improvement
+
+# State labels — at most one per issue. These match canonical names
+# directly; GitHub repos using the flightplan triage funnel will have
+# these labels created on first use.
+state_labels:
+  needs-info: needs-info
+  ready-for-agent: ready-for-agent
+  ready-for-human: ready-for-human
+  wontfix: wontfix
+  needs-triage: needs-triage
+
+# Status mapping — GitHub has no native status enum. The adapter
+# encodes the canonical state machine via a combination of issue
+# state (open/closed + state_reason) and a single state-encoding
+# label that's mutually exclusive with other state-encoding labels.
+#
+# `state-encoding labels` is the set of labels that participate in
+# status: { triage, backlog, todo, in-progress, in-review, reviewed }.
+# When transitioning between OPEN canonical statuses, the adapter
+# strips other state-encoding labels and applies the new one.
+statuses:
+  triage:
+    state: open
+    label: triage
+  backlog:
+    state: open
+    label: backlog
+  todo:
+    state: open
+    label: todo
+  in-progress:
+    state: open
+    label: in-progress
+  in-review:
+    state: open
+    label: in-review
+  reviewed:
+    state: open
+    label: reviewed
+  done:
+    state: closed
+    state_reason: completed
+  canceled:
+    state: closed
+    state_reason: not_planned
+  duplicate:
+    state: closed
+    state_reason: duplicate
+
+# Non-canonical labels GitHub repos commonly carry — these are
+# preserved on read (surfaced as `extra_labels` in the canonical issue
+# shape) and untouched on write. The adapter is a good citizen on
+# existing repos. Listed here for documentation only; no logic depends
+# on this list.
+preserved_extras:
+  - good first issue
+  - help wanted
+  - documentation       # if a repo uses this for category, override above
+  - duplicate            # GitHub default; harmless duplicate of state_reason
+  - invalid              # GitHub default
+  - question             # GitHub default

--- a/triage/SKILL.md
+++ b/triage/SKILL.md
@@ -30,7 +30,7 @@ session start by reading `.afk/config.yml`'s `tracker:` field.
 | `tracker:` value | Adapter |
 |---|---|
 | `linear` (default) | [`tracker-linear/SKILL.md`](../tracker-linear/SKILL.md) |
-| `github` | `tracker-github/SKILL.md` (planned) |
+| `github` | [`tracker-github/SKILL.md`](../tracker-github/SKILL.md) |
 | anything else | refuse and surface — no silent fallback |
 
 Tracker-specific knowledge (team mappings, vendor-native status names,


### PR DESCRIPTION
## Summary

Two-part change packaged in one PR:

1. **Brings Phase A2 (tracker-github adapter) onto main.** PR [#8](https://github.com/ValescoAgency/flightplan/pull/8) merged into `feature/tracker-adapter` (its base) rather than directly into `main`, so its content shipped to that branch but not to main. Cherry-picked here as commit 1.
2. **Adds `.afk/config.yml` for the flightplan repo itself**, dogfooding the GitHub adapter as the Phase A2 validation milestone.

## What's in the config

```yaml
afkEligible: false        # skill-layer control plane
projectTier: 2            # internal tooling (informational)
tracker: github           # dogfoods the tracker-github adapter
```

`afkEligible: false` follows the parallel reasoning to [valesco-platform §14.3](https://github.com/ValescoAgency/valesco-platform/blob/main/docs/afk/governance-plan.md): a control plane cannot rewrite its own policies. Flightplan ships the skills that drive AFK runs — an AFK contract that rewrites `/triage` or `/attest` would create a governance self-modification loop. Different repo, same governance shape.

## What works on flightplan with this config

- `/triage` end-to-end — issue funnel, Agent Brief / Human Brief comments via `gh` CLI
- `/diagnose`, `/feedback-loop` — no tracker-specific dependencies
- Matt's grilling skills — independent
- All actionable issues route to `ready-for-human` (no `ready-for-agent` path on `afkEligible: false`)

## What deliberately does NOT work

- `/draft-contract`, `/attest`, `/brief-to-contract` beyond the triage step. `afkEligible: false` short-circuits the chain at Stage 0 of `/brief-to-contract`. Independently, the Phase B blocker (`linearIssueId` regex) would also reject GitHub-shaped IDs at `/draft-contract`'s schema validation — so even if `afkEligible` were `true`, the chain would stop at the same point.

## Why this PR also includes A2's content

PR #8's base was `feature/tracker-adapter` (intentional at the time, since A1 hadn't merged yet). When #8 merged, it merged into that feature branch — not main. After #7 merged, the A2 content sits on `feature/tracker-adapter` but is missing from main. The dogfood config references `tracker: github`, which only makes sense if `tracker-github/` exists on main.

The cherry-pick is clean (no conflicts) and identical to PR #8's commit. Net effect: main gets the A2 content + the dogfood config in one shot.

If you'd prefer the A2 content land separately, I can split this into two PRs — but pragmatically, the cherry-pick is harmless and the dogfood config is dependent on it.

## Test plan

After merge, walk through `/triage` against a real `flightplan` issue (this PR or any future one) to validate:

- [ ] `/triage` correctly loads `tracker-github/SKILL.md` based on `.afk/config.yml`
- [ ] AFK eligibility surfaces correctly: no `ready-for-agent` recommendation; routes to `ready-for-human` if actionable
- [ ] `gh issue view`, `gh issue comment`, `gh issue edit --add-label` all work via the adapter
- [ ] Status mapping works: opening an issue with no state-encoding label maps to canonical `triage`; transitioning to `todo` adds the `todo` label
- [ ] AI disclaimer (`> *This was generated by AI during triage.*`) prefixes posted comments
- [ ] Non-canonical labels (`good first issue`, etc.) are preserved on read, untouched on write
- [ ] Confirm `/draft-contract` refuses cleanly with a message about `afkEligible: false` (and not at schema validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)