### PR TITLE
fix(afk-config): flip flightplan to afkEligible: true

### DIFF
--- a/.afk/config.yml
+++ b/.afk/config.yml
@@ -1,26 +1,42 @@
 # Flightplan repo's own AFK configuration.
 #
-# This is the meta-plugin: it ships the skills that drive AFK runs on
-# OTHER Valesco repos. By the same governance reasoning that applies to
-# valesco-platform (§14.3 — control planes cannot rewrite their own
-# policies), this repo is afkEligible: false. AFK contracts that could
-# rewrite /triage or /attest themselves would create a governance
-# self-modification loop.
+# Flightplan ships the SKILLS that drive AFK runs on other Valesco
+# repos (/triage, /diagnose, /draft-contract, /attest, /brief-to-contract,
+# tracker-*). The earlier framing here was "skill-layer control plane,
+# afkEligible: false, parallel to valesco-platform §14.3" — that was
+# wrong. Reverted 2026-05-01 with this commit.
 #
-# What this means in practice:
-#   - All actionable issues route to ready-for-human, never ready-for-agent
-#   - /draft-contract refuses (no Tier-1/2/3 contract path)
-#   - /triage works fully — issue funnel + Agent Brief / Human Brief comments
-#   - /diagnose, /feedback-loop, Matt's grilling skills all work normally
+# §14.3 protects the AUTHORITY-bearing pipeline (validators,
+# pre-flight, label handler, schema files in valesco-platform/afk/).
+# Flightplan's skills are ADVISORY — they produce inputs to the
+# pipeline (Agent Briefs, contract drafts, attestation walks), but
+# the pipeline itself still runs in valesco-platform and re-validates
+# every contract. A contract authored on flightplan still has to pass
+# pre-flight in valesco-platform; the governance loop §14.3 prevents
+# is broken by repo separation, not by afkEligible: false.
 #
-# This config also serves as the dogfood validation milestone for the
-# tracker-github adapter (Phase A2). Walking a real flightplan issue
-# through /triage end-to-end against GitHub Issues is the proof that the
-# adapter contract holds beyond Linear.
+# So flightplan is afkEligible: true. Heightened scrutiny on contracts
+# that touch authority-adjacent paths (attest/**, draft-contract/**,
+# brief-to-contract/**) is the right tool — that belongs in
+# valesco-platform's protected-paths manifest, not in this config.
+#
+# What works on flightplan with afkEligible: true:
+#   - /triage, /diagnose, /feedback-loop, /draft-contract, /attest,
+#     /brief-to-contract — full chain
+#   - Issues can move to ready-for-agent and through to AFK runs
+#   - Phase B blocker still applies: GitHub-shaped issue IDs
+#     (owner/repo#NNN) fail goal-contract.v1.json's regex until
+#     valesco-platform ships schema v2. Until then, contracts authored
+#     here will be rejected at /draft-contract — that's the next
+#     thing the dogfood walk surfaces.
+#
+# This config still serves as the dogfood validation milestone for
+# the tracker-github adapter (Phase A2). With afkEligible: true the
+# walk now exercises the full chain (modulo Phase B).
 
-afkEligible: false        # This repo is a skill-layer control plane
-projectTier: 2            # Internal tooling; informational while afkEligible:false
-tracker: github           # Use the tracker-github adapter (Phase A2)
+afkEligible: true         # advisory skills, not authority — pipeline runs in valesco-platform
+projectTier: 2            # internal tooling, not customer-facing
+tracker: github           # tracker-github adapter (Phase A2)
 
 # trackerLabelsPath:      # Uncomment + populate if this repo's GitHub
 #                         # labels diverge from tracker-github/labels.yml

--- a/README.md
+++ b/README.md
@@ -51,10 +51,14 @@ active adapter is selected via `tracker:` in `.afk/config.yml` (default
 | `tracker-jira`, `tracker-local-md` | Deferred | — |
 
 This repo is its own dogfood for the GitHub adapter — see
-[`.afk/config.yml`](.afk/config.yml). `afkEligible: false` (skill-layer
-control plane); `tracker: github`. Walking flightplan issues through
-`/triage` against the `tracker-github` adapter is the validation
-milestone for Phase A2.
+[`.afk/config.yml`](.afk/config.yml). `afkEligible: true` (advisory
+skills, not authority — see
+[`docs/workflow.md`](docs/workflow.md#when-afkeligible-false-is-the-right-answer)
+for why flightplan is not a §14.3 control plane); `projectTier: 2`;
+`tracker: github`. Walking flightplan issues through the full AFK
+chain against the `tracker-github` adapter is the validation milestone
+for Phase A2 — modulo the Phase B schema regex blocker, which the walk
+will surface concretely at `/draft-contract`.
 
 These compose with Matt Pocock's
 [engineering skills](https://github.com/mattpocock/skills/tree/main/skills/engineering)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -102,6 +102,40 @@ first use — `/grill-with-docs` creates `CONTEXT.md` lazily when the first
 term is resolved, and creates `docs/adr/` lazily when the first ADR is
 needed.
 
+### When `afkEligible: false` is the right answer
+
+`afkEligible: false` exists for **authority-bearing control planes**
+that the AFK pipeline could rewrite to bypass governance. The canonical
+example is [`valesco-platform`](https://github.com/ValescoAgency/valesco-platform):
+it owns the validators, pre-flight, label handler, and authority
+schemas. A contract that modifies that code defeats the gates §G1 / §G8
+exist to enforce. The §14.3 self-modification rule applies.
+
+`afkEligible: false` is **not** the right answer for repos that ship
+*advisory* skills, even when those skills shape AFK runs:
+
+- Flightplan ships `/triage`, `/draft-contract`, `/attest`, etc. — but
+  these produce *inputs* to authority (Agent Briefs, draft contracts,
+  attestation walks). Authority itself still runs in valesco-platform.
+  A contract that modifies flightplan still has to pass valesco-platform
+  pre-flight before merging, so the §14.3 loop is broken by repo
+  separation alone.
+- Repos with workflow tooling, CI scripts, dev infrastructure are
+  similarly advisory — they affect how humans interact with AFK, not
+  whether AFK enforces the rules.
+
+For these repos: `afkEligible: true`. If specific paths within them
+warrant heightened scrutiny (e.g., flightplan's `attest/**` and
+`tracker-*/**` are authority-adjacent enough to deserve Tier 1 +
+adversarial review), the right tool is the **protected-paths manifest**
+in `valesco-platform/afk/protected-paths/`, not blanket disqualification
+of the whole repo.
+
+When in doubt, ask: "If an AFK contract on this repo were maliciously
+crafted, could it bypass a governance gate that lives in
+valesco-platform?" If no — `afkEligible: true`. If yes — `false`, and
+write down which gate.
+
 ## Tracker adapters
 
 The "context layer" — issue body, comments, labels, status — is a


### PR DESCRIPTION
## Summary

Reverts the `afkEligible: false` posture set in PR #9. That framing — "flightplan is a skill-layer control plane parallel to valesco-platform §14.3" — was wrong.

## Why the original framing was wrong

**§14.3 protects authority-bearing pipeline code**: validators, pre-flight, label handler, authority schemas. All of that lives in `valesco-platform/afk/`. Modifying *that* code defeats the §G1/§G8 governance gates directly — which is the self-modification loop §14.3 prevents.

**Flightplan ships advisory skills**: `/triage`, `/diagnose`, `/draft-contract`, `/attest`, `/brief-to-contract`, `tracker-*`. These produce *inputs* to authority (Agent Briefs, draft contracts, attestation walks), but the pipeline itself still runs in `valesco-platform` and re-validates every contract. A contract authored against flightplan still has to pass `valesco-platform`'s pre-flight before it can merge anywhere. **The §14.3 loop is broken by repo separation, not by `afkEligible: false`.**

## Why we shot ourselves in the foot

The original config disqualified flightplan from the validation we explicitly built tracker-github to enable. With `afkEligible: false`, every flightplan issue routed to `ready-for-human` — `/draft-contract` and `/attest` were never exercised against the GitHub adapter. The Phase B schema-regex blocker became untestable in practice.

The whole point of [#9](https://github.com/ValescoAgency/flightplan/pull/9)'s dogfood walk is to find as many AFK-eligible issues as possible against a GitHub-Issues repo. Setting `afkEligible: false` defeated that.

## What this PR changes

- **`.afk/config.yml`**: `afkEligible` flipped to `true`; `projectTier: 2` (internal tooling); `tracker: github` (unchanged). Comment block rewritten with the corrected reasoning.
- **`docs/workflow.md`**: new subsection ["When `afkEligible: false` is the right answer"](https://github.com/ValescoAgency/flightplan/blob/fix/afk-eligibility-clarification/docs/workflow.md#when-afkeligible-false-is-the-right-answer). Documents the **authority vs advisory** distinction explicitly, so future configs don't repeat the mistake. Names the right tool for path-level scrutiny — `valesco-platform`'s protected-paths manifest, not blanket disqualification.
- **`README.md`**: dogfood paragraph updated to match.

## Heightened-scrutiny paths

If specific paths within flightplan deserve extra scrutiny (`attest/**`, `draft-contract/**`, `brief-to-contract/**` are authority-adjacent), the right mechanism is **per-repo entries in `valesco-platform`'s protected-paths manifest** — surgical Tier-1 + adversarial-review requirements on those globs. Not a blanket `afkEligible: false`.

This belongs in a separate PR against `valesco-platform`. Filing as a follow-up after this lands; not in scope here.

## What this unblocks

- Issue [#10](https://github.com/ValescoAgency/flightplan/issues/10) (the YAML frontmatter bug in `tracker-linear`, `tracker-github`, `feedback-loop` SKILL.md files) becomes genuinely AFK-eligible. The next dogfood walk step exercises `/triage` against it with the corrected config.
- The Phase B blocker becomes testable in practice — `/draft-contract` will reject GitHub-shaped IDs at schema validation; we'll see the exact failure mode and confirm the error message is useful.

## Test plan

- [ ] After merge, run `/triage` against issue #10 (the YAML bug). Confirm it now recommends `ready-for-agent` rather than `ready-for-human`.
- [ ] Confirm Tier escalation logic in `/brief-to-contract` correctly recommends Tier 2 (default) — not Tier 1, since none of the issue's likely write paths are in the authority-adjacent set today.
- [ ] Run `/draft-contract` against the issue — expect rejection at schema validation due to GitHub-shaped ID format. Confirm the error message points at Phase B clearly.
- [ ] Read [`docs/workflow.md`](https://github.com/ValescoAgency/flightplan/blob/fix/afk-eligibility-clarification/docs/workflow.md#when-afkeligible-false-is-the-right-answer) and confirm the authority-vs-advisory framing matches how Valesco wants to think about repo eligibility going forward.

## Follow-up (not in this PR)

- File a `valesco-platform` PR to add `flightplan/attest/**`, `flightplan/draft-contract/**`, `flightplan/brief-to-contract/**` to the protected-paths manifest as Tier-1 + adversarial-review-required. Triggered if and when an AFK contract on flightplan touches those globs in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)