### PR TITLE
feat(skills): bootstrap-mode awareness + v1→v2.1.0 schema catchup

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flightplan",
-  "version": "0.4.1",
-  "description": "Valesco-authored Claude Code skills for harness engineering and agent orchestration around the AFK autonomous-coding governance pipeline. Vendor-agnostic via the tracker adapter contract — ships with Linear (full capability) and GitHub Issues (proof-of-concept; reduced capability) adapters; Jira and local-markdown adapters deferred. Bundles the orchestration spine (/brief-to-contract), harness skills (/diagnose, /feedback-loop), tracker funnel (/triage), goal-contract drafting (/draft-contract), and tier-scaled attestation (/attest). User-invoked, advisory skills only — pipeline code (validators, pre-flight, audit, label handler) lives in valesco-platform per the skills-vs-pipeline rule.",
+  "version": "0.5.0",
+  "description": "Valesco-authored Claude Code skills for harness engineering and agent orchestration around the AFK autonomous-coding governance pipeline. Vendor-agnostic via the tracker adapter contract — ships with Linear and GitHub Issues adapters at full capability against goal-contract schemaVersion 2.1.0. Bundles the orchestration spine (/brief-to-contract), harness skills (/diagnose, /feedback-loop), tracker funnel (/triage), goal-contract drafting (/draft-contract), tier-scaled attestation (/attest), and v1 dogfood runner (/run-attested). User-invoked, advisory skills only — pipeline code (validators, pre-flight, audit, label handler) lives in valesco-platform per the skills-vs-pipeline rule.",
   "author": {
     "name": "Valesco Agency",
     "email": "jason@valescoagency.com",

--- a/skills/attest/SKILL.md
+++ b/skills/attest/SKILL.md
@@ -7,7 +7,7 @@ description: Walk the human through the AFK attestation checklist for a `.goal-c
 
 Render the tier-scaled attestation checklist for the current repo's
 `.goal-contract.yml`, walk the user through it interactively, and write an
-attestation record to `.afk/attestations/<linearIssueId>.json`.
+attestation record to `.afk/attestations/<trackerIssueId>.json`.
 
 The afk-ready label handler reads this record, re-computes
 `attestedContentSha` against the current YAML, and refuses to promote the
@@ -45,19 +45,22 @@ the human has consciously walked through every authority-bearing claim.
    > regardless (G8 gate).
 
 3. **Schema validation.** Parse the YAML and validate against
-   `afk/schemas/goal-contract.v1.json` (from the valesco-platform repo —
-   either vendored locally or looked up via the repo's `.afk/` sibling).
-   Fail loudly on AJV errors and list them.
+   `afk/schemas/goal-contract.v2.json` (v2.1.0; from the valesco-platform
+   repo — either vendored locally or looked up via the repo's `.afk/`
+   sibling). Fail loudly on AJV errors and list them.
 
 4. **Tier 1 canary-plan check.** If `metadata.tier === 1` and
-   `canaryPlan` is missing, refuse:
+   `metadata.bootstrap !== true` and `canaryPlan` is missing, refuse:
 
    > Refusing to run. Tier 1 contracts require a canaryPlan block
    > (metrics, thresholds, rollbackTrigger, windowMinutes) per governance
    > plan G10. Author it before attesting.
 
+   Under `metadata.bootstrap === true` the v2.1.0 schema relaxes this to
+   optional even at Tier 1 (no live deployment to canary against — §G14).
+
 5. **Existing attestation check.** If
-   `.afk/attestations/<linearIssueId>.json` already exists:
+   `.afk/attestations/<trackerIssueId>.json` already exists:
 
    > Prior attestation exists at <path>, attested <attestedAt> with
    > `attestedContentSha` <sha>. Current YAML sha is <sha'>. {Match /
@@ -68,8 +71,11 @@ the human has consciously walked through every authority-bearing claim.
 ### Step 1 — load + introspect
 
 Read `.goal-contract.yml`, parse, and compute:
-- `linearIssueId` — from `metadata.linearIssueId`
+- `trackerIssueId` — from `metadata.trackerIssueId` (renamed from
+  `metadata.linearIssueId` at schemaVersion 2.0.0; fall back to the
+  legacy field for pre-2.0.0 contracts still in flight)
 - `tier` — from `metadata.tier`
+- `bootstrap` — from `metadata.bootstrap` (default `false`)
 - `attestedContentSha` — `"sha256:" + sha256(raw file bytes)` (no
   canonicalization; raw bytes is the contract per the keying decision)
 - `attester` — shell out to `git config user.name` and
@@ -108,7 +114,7 @@ the authoritative adversarial record lives in the audit store.
 
 ### Step 4 — write the record
 
-Write to `.afk/attestations/<linearIssueId>.json`. Use the shape in
+Write to `.afk/attestations/<trackerIssueId>.json`. Use the shape in
 [`record-reference.md`](./record-reference.md). Pretty-print with
 2-space indent; trailing newline.
 
@@ -125,8 +131,9 @@ and report the error. Never leave a malformed record on disk.
 ### Step 6 — print next steps
 
 ```
-Attestation written: .afk/attestations/<linearIssueId>.json
+Attestation written: .afk/attestations/<trackerIssueId>.json
   tier: <N>
+  bootstrap: <true | false>
   ticked: <count> / <total>
   skipped: <count> (rationales required)
   attestedContentSha: <first 12 hex chars>…
@@ -134,7 +141,8 @@ Attestation written: .afk/attestations/<linearIssueId>.json
 
 Next:
   1. Commit the attestation record to the scope PR branch.
-  2. Confirm the delay window has elapsed:
+  2. Confirm the delay window has elapsed (use the bootstrap row of
+     the matrix in checklist.md if metadata.bootstrap === true):
        • Tier 1 default: 15 min (30 min sensitive; 60 min meta-contract)
        • Tier 2 default: 5 min (15 min sensitive; 30 min meta-contract)
        • Tier 3 default: 0 min (5 min sensitive; 15 min meta-contract)
@@ -148,12 +156,15 @@ attestation — re-run `/attest` after every authority-bearing change.
 
 ## Self-validation before returning
 
-- [ ] `.afk/attestations/<linearIssueId>.json` exists and parses as JSON.
+- [ ] `.afk/attestations/<trackerIssueId>.json` exists and parses as JSON.
 - [ ] Record validates against `attestation-record.v1.json`.
 - [ ] `attestedContentSha` matches `sha256:` + sha256 of current
       `.goal-contract.yml` bytes.
 - [ ] Every `state: "skipped"` item has a non-empty `rationale`.
 - [ ] Every `state: "ticked"` item has no `rationale` field.
+- [ ] If `metadata.bootstrap === true`: the `bootstrap-claim-self-verifying`
+      item is `ticked` (not `skipped`). Bootstrap-mode contracts MUST have
+      this claim made positively, not waved away.
 
 If any check fails, delete the record and report the specific failure.
 
@@ -174,7 +185,7 @@ If any check fails, delete the record and report the specific failure.
 
 - `valesco-platform/afk/schemas/attestation-record.v1.json` (authoritative
   record shape)
-- `valesco-platform/afk/schemas/goal-contract.v1.json` (contract
+- `valesco-platform/afk/schemas/goal-contract.v2.json` (v2.1.0 — contract
   pre-validation)
 - `valesco-platform/docs/afk/governance-plan.md` §G1 (checklist rationale)
 - `valesco-platform/docs/afk/governance-plan.md` §7 (authority chain —

--- a/skills/attest/checklist.md
+++ b/skills/attest/checklist.md
@@ -16,14 +16,18 @@ MUST NOT reorder within what it does render.
 
 ## All tiers
 
-### `intent-matches-linear`
+### `intent-matches-tracker`
 
 **Applies:** all tiers.
 
-> I have re-read the referenced Linear issue within the last 15
+> I have re-read the referenced tracker issue within the last 15
 > minutes. The contract's `intent.description`, `successCriteria`, and
 > `nonGoals` still reflect the issue's current wording — no silent
-> drift between Linear and the YAML.
+> drift between the tracker and the YAML.
+
+*(id renamed from `intent-matches-linear` at schemaVersion 2.0.0 when
+`metadata.linearIssueId` became `metadata.trackerIssueId`. Pre-2.0.0
+records still carry the old id; never reuse it for new items.)*
 
 ### `paths-are-minimal`
 
@@ -60,10 +64,15 @@ MUST NOT reorder within what it does render.
 
 ### `time-delay-elapsed`
 
-**Applies:** all tiers.
+**Applies:** all tiers. Matrix branches on `metadata.bootstrap` per
+governance §G14 (foundation slices have no production-traffic risk to
+amortize across a delay window — VA-329 implements the matrix override
+in the label handler).
 
 > At least the required delay has elapsed between the contract's
-> initial draft write and now:
+> initial draft write and now.
+>
+> **Standard contracts** (`metadata.bootstrap !== true`):
 >
 > | tier | default | sensitive paths | meta-contract |
 > |---|---|---|---|
@@ -71,8 +80,19 @@ MUST NOT reorder within what it does render.
 > | 2 | 5 min | 15 min | 30 min |
 > | 3 | 0 min | 5 min | 15 min |
 >
+> **Bootstrap contracts** (`metadata.bootstrap === true`):
+>
+> | tier | default | sensitive paths | meta-contract |
+> |---|---|---|---|
+> | 1 | 5 min | 15 min | 30 min |
+> | 2 | 0 min | 5 min | 15 min |
+> | 3 | 0 min | 0 min | 5 min |
+>
 > Sensitive paths: auth, `supabase/migrations/**`, billing, any path
-> flagged "production-critical" in repo metadata.
+> flagged "production-critical" in repo metadata. Under bootstrap, paths
+> in `afk/protected-paths/bootstrap-allowlist.yml` are not treated as
+> sensitive even if they overlap (the allowlist is the deliberate
+> override).
 
 ### `adversarial-review-considered`
 
@@ -97,13 +117,17 @@ MUST NOT reorder within what it does render.
 
 ### `canary-plan-sensible`
 
-**Applies:** `metadata.tier === 1`.
+**Applies:** `metadata.tier === 1 && metadata.bootstrap !== true`.
 
 > `canaryPlan.metrics`, `canaryPlan.thresholds`, and
 > `canaryPlan.rollbackTrigger` are concrete and executable. Thresholds
 > are calibrated to the actual deployment's normal-range baseline,
 > not round-number guesses. `rollbackTrigger` is a real command or
 > Vercel action, not a TBD placeholder.
+
+*(Skipped under `metadata.bootstrap === true`: foundation slices have no
+live deployment to canary against; the v2.1.0 schema relaxes
+`canaryPlan` to optional even at Tier 1 in that case — governance §G14.)*
 
 ---
 
@@ -121,15 +145,39 @@ MUST NOT reorder within what it does render.
 
 ## Conditional on contract content
 
+### `bootstrap-claim-self-verifying`
+
+**Applies:** `metadata.bootstrap === true`.
+
+> Every glob in `scope.requiredPaths` either resolves to **zero files**
+> on the current `main` branch, OR resolves only to paths listed in
+> `afk/protected-paths/bootstrap-allowlist.yml`. No glob secretly
+> overlaps a pre-existing file outside the allowlist.
+>
+> I have eyeballed the resolved tree (e.g. via `git ls-files` against
+> the globs) and confirmed this — I am not relying on the heuristic
+> alone. Pre-flight will re-check this mechanically (per VA-327), but
+> the claim is mine.
+>
+> I also confirm `metadata.bootstrap: true` is the right shape: this
+> contract creates files that do not yet exist, not edits to a
+> populated codebase. If this is a "standard" contract that happens to
+> touch new files alongside existing ones, the value should be `false`
+> and `intent.anchors.interfaces` / `configShapes` should be populated
+> instead.
+
 ### `incident-override-rationale`
 
 **Applies:** `metadata.incidentOverride` present.
 
-> `metadata.incidentOverride.linearIssueRef` points at a real
+> `metadata.incidentOverride.trackerIssueRef` points at a real
 > incident issue, and `metadata.incidentOverride.rationale` is a
 > genuine description of the urgency — not a workaround for impatience
 > with the normal delay window. I understand this counts as an
 > `urgent_business_need` override against the override budget.
+>
+> *(Field renamed from `linearIssueRef` to `trackerIssueRef` at
+> schemaVersion 2.0.0.)*
 
 ---
 
@@ -139,4 +187,8 @@ When an item is retired, it moves here with a removal date and the
 ticket that retired it. Never delete the id history — past records
 still reference the old ids.
 
-_(none yet)_
+- `intent-matches-linear` — renamed to `intent-matches-tracker` on
+  2026-05-07 ([VA-331](https://linear.app/valescoagency/issue/VA-331))
+  when the v1→v2 schema rename moved `metadata.linearIssueId` to
+  `metadata.trackerIssueId`. Pre-2026-05-07 attestation records still
+  reference the old id and remain valid.

--- a/skills/attest/record-reference.md
+++ b/skills/attest/record-reference.md
@@ -11,9 +11,10 @@ file drifts, the schema wins.
 ```json
 {
   "schemaVersion": "1.0.0",
-  "linearIssueId": "<TEAM-NNN>",
+  "trackerIssueId": "<TEAM-NNN | owner/repo#NNN>",
   "attestedContentSha": "sha256:<64 hex chars>",
   "tier": 1 | 2 | 3,
+  "bootstrap": false,
   "attestedAt": "<ISO 8601 datetime>",
   "attester": "<git user.name <user.email>>",
   "adversarialReviewStatus": "reviewed" | "pending" | "not-run",
@@ -31,13 +32,19 @@ file drifts, the schema wins.
 
 Keys:
 
-- `linearIssueId` is the record's key on disk: file lives at
-  `.afk/attestations/<linearIssueId>.json`. One record per Linear
-  issue at a time; re-running `/attest` overwrites.
+- `trackerIssueId` is the record's key on disk: file lives at
+  `.afk/attestations/<trackerIssueId>.json`. One record per tracker
+  issue at a time; re-running `/attest` overwrites. The field was
+  named `linearIssueId` pre-schemaVersion 2.0.0; pre-2.0.0 records on
+  disk remain valid under the legacy key.
 - `attestedContentSha` is the raw SHA-256 of the `.goal-contract.yml`
   file bytes at attestation time. The afk-ready label handler
   re-computes this sha against the current YAML; drift rejects the
   promotion.
+- `bootstrap` mirrors `metadata.bootstrap` from the contract. Surfaced
+  on the record so downstream consumers (label handler, run-attested,
+  audit emitter) know to apply the bootstrap-mode invariants without
+  re-parsing the contract YAML. Defaults to `false` if absent.
 - `adversarialReviewStatus` and `timeSinceDraftMinutes` are optional.
 
 ## Example 1 — Tier 3, all items ticked
@@ -45,17 +52,18 @@ Keys:
 ```json
 {
   "schemaVersion": "1.0.0",
-  "linearIssueId": "VA-160",
+  "trackerIssueId": "VA-160",
   "attestedContentSha": "sha256:7d793037a0760186574b0282f2f435e7b8a9b26edb6c1b0a8d42fd9c8c3e5f01",
   "tier": 3,
+  "bootstrap": false,
   "attestedAt": "2026-04-22T01:12:00Z",
   "attester": "Jason Kennemer <jason@valescoagency.com>",
   "adversarialReviewStatus": "reviewed",
   "timeSinceDraftMinutes": 20,
   "items": [
     {
-      "id": "intent-matches-linear",
-      "label": "I have re-read the referenced Linear issue within the last 15 minutes. The contract's intent.description, successCriteria, and nonGoals still reflect the issue's current wording — no silent drift between Linear and the YAML.",
+      "id": "intent-matches-tracker",
+      "label": "I have re-read the referenced tracker issue within the last 15 minutes. The contract's intent.description, successCriteria, and nonGoals still reflect the issue's current wording — no silent drift between the tracker and the YAML.",
       "state": "ticked"
     },
     {
@@ -97,15 +105,16 @@ Keys:
 ```json
 {
   "schemaVersion": "1.0.0",
-  "linearIssueId": "VA-242",
+  "trackerIssueId": "VA-242",
   "attestedContentSha": "sha256:c775e7b757ede630cd0aa1113bd102661ab38829ca52a6422ab782862f268646",
   "tier": 1,
+  "bootstrap": false,
   "attestedAt": "2026-04-22T03:04:00Z",
   "attester": "Jason Kennemer <jason@valescoagency.com>",
   "adversarialReviewStatus": "reviewed",
   "timeSinceDraftMinutes": 4,
   "items": [
-    { "id": "intent-matches-linear", "label": "...", "state": "ticked" },
+    { "id": "intent-matches-tracker", "label": "...", "state": "ticked" },
     { "id": "paths-are-minimal", "label": "...", "state": "ticked" },
     { "id": "no-hard-floor-in-writepaths", "label": "...", "state": "ticked" },
     { "id": "cost-estimate-acknowledged", "label": "...", "state": "ticked" },
@@ -119,6 +128,37 @@ Keys:
     { "id": "customer-identifier-correct", "label": "...", "state": "ticked" },
     { "id": "canary-plan-sensible", "label": "...", "state": "ticked" },
     { "id": "incident-override-rationale", "label": "...", "state": "ticked" }
+  ]
+}
+```
+
+## Example 3 — Tier 1 bootstrap (foundation slice)
+
+A bootstrap-mode contract attesting a green-field scaffolding slice.
+Note: `bootstrap: true`, `canary-plan-sensible` is **not present** (its
+`applies` clause excluded it), and `bootstrap-claim-self-verifying`
+appears as a ticked item.
+
+```json
+{
+  "schemaVersion": "1.0.0",
+  "trackerIssueId": "VA-312",
+  "attestedContentSha": "sha256:a3f2b1c8e0d4f5e6b7a8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0",
+  "tier": 1,
+  "bootstrap": true,
+  "attestedAt": "2026-05-08T14:30:00Z",
+  "attester": "Jason Kennemer <jason@valescoagency.com>",
+  "adversarialReviewStatus": "reviewed",
+  "timeSinceDraftMinutes": 6,
+  "items": [
+    { "id": "intent-matches-tracker", "label": "...", "state": "ticked" },
+    { "id": "paths-are-minimal", "label": "...", "state": "ticked" },
+    { "id": "no-hard-floor-in-writepaths", "label": "...", "state": "ticked" },
+    { "id": "cost-estimate-acknowledged", "label": "...", "state": "ticked" },
+    { "id": "time-delay-elapsed", "label": "... bootstrap row of matrix ...", "state": "ticked" },
+    { "id": "adversarial-review-considered", "label": "...", "state": "ticked" },
+    { "id": "customer-identifier-correct", "label": "...", "state": "ticked" },
+    { "id": "bootstrap-claim-self-verifying", "label": "Every glob in scope.requiredPaths either resolves to zero files on the current main branch, OR resolves only to paths listed in afk/protected-paths/bootstrap-allowlist.yml. ...", "state": "ticked" }
   ]
 }
 ```

--- a/skills/brief-to-contract/SKILL.md
+++ b/skills/brief-to-contract/SKILL.md
@@ -71,7 +71,7 @@ the entry point. Detection rules in detail:
 
 | Existing artefact | Entry stage | Skill announces |
 |---|---|---|
-| `.afk/attestations/<linearIssueId>.json` exists, sha matches current `.goal-contract.yml` | Stage 8 | "Already attested. Printing hand-off." |
+| `.afk/attestations/<trackerIssueId>.json` exists, sha matches current `.goal-contract.yml` | Stage 8 | "Already attested. Printing hand-off." |
 | `.goal-contract.yml` exists, no `<PLANNER_SUGGESTED:>` tokens, no attestation record (or sha drift) | Stage 7 | "Contract authored; entering attestation." |
 | `.goal-contract.yml` exists, but `<PLANNER_SUGGESTED:>` tokens remain | Refuse to advance | "Contract has unreplaced tokens. Replace them, then I'll run /attest." |
 | `.goal-contract.draft.yml` exists, no `.goal-contract.yml` | Stage 5 | "Draft exists; awaiting token replacement + rename." |
@@ -238,7 +238,7 @@ proceed.
 
 Invoke [`/attest`](../attest/SKILL.md). The attestation skill walks the
 human through the tier-scaled checklist and writes
-`.afk/attestations/<linearIssueId>.json`.
+`.afk/attestations/<trackerIssueId>.json`.
 
 This skill **blocks** until the attestation record exists with
 `attestedContentSha` matching the current YAML. If `/attest` is aborted
@@ -247,7 +247,7 @@ a fresh attestation.
 
 After `/attest` returns successfully:
 
-- Verify `.afk/attestations/<linearIssueId>.json` parses, validates, and
+- Verify `.afk/attestations/<trackerIssueId>.json` parses, validates, and
   matches the current YAML's sha.
 - If sha drift is detected later (the user edited the contract after
   attestation), refuse Stage 8 and tell them to re-attest.
@@ -359,7 +359,7 @@ When the skill reaches Stage 8 hand-off, check:
 
 - [ ] `.goal-contract.yml` exists at repo root, parses as YAML, no
       `<PLANNER_SUGGESTED:>` tokens.
-- [ ] `.afk/attestations/<linearIssueId>.json` exists, parses, and
+- [ ] `.afk/attestations/<trackerIssueId>.json` exists, parses, and
       validates against the v1 schema.
 - [ ] `attestedContentSha` in the record == `sha256:` + sha256 of current
       `.goal-contract.yml` bytes.

--- a/skills/brief-to-contract/state-machine.md
+++ b/skills/brief-to-contract/state-machine.md
@@ -15,8 +15,8 @@ Read in order. Stop at the first match.
 | # | Detection signal | Entry | Confirmation prompt |
 |---|---|---|---|
 | 1 | `.afk/config.yml` is missing OR `afkEligible: false` | Refuse | "This repo is a control plane (or unlinked). Routing to `/triage` for `ready-for-human`." |
-| 2 | `.afk/attestations/<linearIssueId>.json` exists AND its `attestedContentSha` matches `sha256:` + sha256 of current `.goal-contract.yml` bytes | Stage 8 | "Already attested for `<TEAM-NNN>`. Sha matches. Printing hand-off — confirm OK?" |
-| 3 | `.afk/attestations/<linearIssueId>.json` exists BUT sha does not match current YAML | Stage 7 | "Attestation exists but the YAML drifted (sha mismatch). I will re-attest. Confirm OK?" |
+| 2 | `.afk/attestations/<trackerIssueId>.json` exists AND its `attestedContentSha` matches `sha256:` + sha256 of current `.goal-contract.yml` bytes | Stage 8 | "Already attested for `<TEAM-NNN>`. Sha matches. Printing hand-off — confirm OK?" |
+| 3 | `.afk/attestations/<trackerIssueId>.json` exists BUT sha does not match current YAML | Stage 7 | "Attestation exists but the YAML drifted (sha mismatch). I will re-attest. Confirm OK?" |
 | 4 | `.goal-contract.yml` exists, no `<PLANNER_SUGGESTED:>` tokens, no attestation record | Stage 7 | "Contract authored, ready for attestation. Entering /attest. Confirm OK?" |
 | 5 | `.goal-contract.yml` exists AND any `<PLANNER_SUGGESTED:>` tokens remain | Refuse | "Contract has unreplaced tokens at lines `<list>`. Replace them, then re-run me. I will not auto-fill." |
 | 6 | Both `.goal-contract.yml` AND `.goal-contract.draft.yml` exist | Refuse | "Both files exist — that's a dangerous state. Pick one: keep the draft and delete the final, or vice versa. Then re-run." |
@@ -143,6 +143,23 @@ Tier reasoning the prompt should always cite:
 
 Single hit → escalate and ask. Multiple hits → escalate and ask, with
 all reasons listed.
+
+### Rule 14 — bootstrap-mode signal (advisory)
+
+The pre-flight verdict logic (`valid` / `stale_refreshable` /
+`invalid_requires_human`) is bootstrap-orthogonal — the state machine
+itself does not branch on `metadata.bootstrap`. But Rule 14's tier
+prompt should mention bootstrap when the brief's candidate
+`requiredPaths` look unresolvable on the current tree:
+
+> Heads-up: this brief reads as a foundation-slice candidate
+> (`requiredPaths` candidates resolve to zero files). `/draft-contract`
+> will prompt you to confirm `metadata.bootstrap: true` per
+> governance §G14. Bootstrap contracts have a different shape — see
+> the per-stage skill's Step 2.5.
+
+This is advisory only. Do not auto-set bootstrap; the field is
+authority-bearing and `/draft-contract` owns the prompt.
 
 ## Override rules
 

--- a/skills/draft-contract/SKILL.md
+++ b/skills/draft-contract/SKILL.md
@@ -73,12 +73,58 @@ Short version:
 | `intent.successCriteria` | Bullets under `## Acceptance`, `## Success criteria`, `## Test plan`. Lift each bullet as-is; strip trailing punctuation. |
 | `intent.nonGoals` | Bullets under `## Non-goals`, `## Out of scope`. |
 | `intent.anchors.docs[]` | URLs in the issue body that point at `.md`, `docs/`, ADR/PRD paths, or external doc hosts (Notion, Sanity, Obsidian). For each, compute a sha256 of the URL string itself as the `versionHash` placeholder — pre-flight will replace it with content hash. |
-| `metadata.linearIssueId` | The tracker's canonical issue identifier — the adapter returns whatever the vendor's native form is. **Schema field name is unchanged in this rollout** (still `linearIssueId`); the active Linear adapter populates it with `TEAM-NNN`. The GitHub adapter (when authored) cannot use this field until the Phase B v2 schema migration in `valesco-platform` lands — see [`../../docs/refactor-plan.md`](../../docs/refactor-plan.md). |
+| `metadata.trackerIssueId` | The tracker's canonical issue identifier — the adapter returns whatever the vendor's native form is. **Renamed from `linearIssueId` at schemaVersion 2.0.0** (per [#40](https://github.com/ValescoAgency/valesco-platform/pull/40) / [#68](https://github.com/ValescoAgency/valesco-platform/pull/68)). The Linear adapter populates it with `TEAM-NNN`; the GitHub adapter populates it with `owner/repo#NNN`. |
 | `metadata.created` | Current timestamp, ISO 8601. |
 
 If a section source is **missing** from the issue body, do not leave the
 field empty — emit a `<PLANNER_SUGGESTED:>` token describing what's
 expected. The skill must never silently drop an authority field.
+
+### Step 2.5 — detect foundation-slice (bootstrap-mode) candidates
+
+Before filling the template, decide whether this contract is a
+foundation slice. Bootstrap mode (governance plan §G14) exists for
+contracts whose `requiredPaths` target files that **do not yet exist**
+on the resolved tree — typical of "scaffold the repo", "stand up the
+schema", "wire the auth shell" slices on a new project.
+
+Bootstrap contracts have a different shape:
+
+- `requiredPaths` / `writePaths` may resolve to zero files at pre-flight,
+  OR resolve only to paths listed in
+  `afk/protected-paths/bootstrap-allowlist.yml`. The standard
+  "every-glob-must-match" rule is **inverted** under bootstrap.
+- `intent.anchors.interfaces` and `intent.anchors.configShapes` are
+  **forbidden** by the v2.1.0 schema — there is no codebase to anchor
+  against. Omit both keys entirely; do not emit empty arrays and do not
+  emit `<PLANNER_SUGGESTED:>` tokens.
+- `canaryPlan` is **optional even at Tier 1** under bootstrap (no live
+  traffic to canary against on a green-field repo).
+- `metadata.bootstrap: true` carries execution authority — flipping it
+  invalidates approval via `contractHash`. See
+  [`authority-fields.md`](./authority-fields.md).
+
+**Detection heuristic (advisory, not mechanical):**
+
+If, given the candidate `requiredPaths` extracted from the tracker
+issue, **every** glob would resolve to zero files against the current
+working tree, prompt the user:
+
+> The candidate `requiredPaths` for `<TRACKER_ID>` resolve to zero files
+> on the current tree. This is the bootstrap-mode signature (governance
+> §G14 — initial scaffolding for a new project).
+>
+> Set `metadata.bootstrap: true` and emit the bootstrap variant of the
+> template? (y/n — default `y` if every glob is unresolved)
+
+If the user confirms (or the heuristic is unambiguous), the skill emits
+the bootstrap variant; otherwise it emits the standard variant. Do not
+silently flip — the field is authority-bearing.
+
+If the heuristic is **partially** true (some globs resolve, some don't),
+do NOT auto-suggest bootstrap. Instead, surface the mixed state and let
+the user decide — partial resolution usually means a mis-scoped contract
+or a misnamed glob, not a foundation slice.
 
 ### Step 3 — fill the template
 
@@ -146,13 +192,16 @@ remains — this is the G8 structural gate. Intentional.
 Before printing the next-steps block, verify:
 
 - [ ] The written YAML parses.
-- [ ] `metadata.linearIssueId` matches the pattern `^[A-Z]{2,6}-\d+$`.
-      *(Until Phase B schema migration: this means the active adapter
-      must be Linear. GitHub adapter callers will fail this check; that
-      gap is registered in [`../../docs/refactor-plan.md`](../../docs/refactor-plan.md).)*
+- [ ] `schemaVersion` is the literal string `"2.1.0"`.
+- [ ] `metadata.trackerIssueId` matches the format the active adapter
+      returns (Linear: `^[A-Z]{2,6}-\d+$`; GitHub: `^[\w.-]+/[\w.-]+#\d+$`).
 - [ ] Every field listed in [`authority-fields.md`](./authority-fields.md) as
       "token-required when not derivable" is either a real value or contains
-      the literal string `<PLANNER_SUGGESTED:`.
+      the literal string `<PLANNER_SUGGESTED:`. Items marked
+      "forbidden under bootstrap" must be **absent** (key omitted, not empty
+      array) when `metadata.bootstrap` is `true`.
+- [ ] If `metadata.bootstrap === true`: `intent.anchors.interfaces` and
+      `intent.anchors.configShapes` keys are absent (not present-but-empty).
 - [ ] The file path ends with `.goal-contract.draft.yml`, never
       `.goal-contract.yml`.
 
@@ -181,7 +230,10 @@ not leave a malformed draft on disk.
   blocker explanation for non-Linear adapters.
 - `valesco-platform/docs/afk/governance-plan.md` §G8 (planner → main handoff)
 - `valesco-platform/docs/afk/intake.md` (full intake flow context)
-- `valesco-platform/afk/schemas/goal-contract.v1.json` (draft must validate
-  against this on schema-typed fields; token strings are accepted where the
-  field type is string or string-array)
+- `valesco-platform/afk/schemas/goal-contract.v2.json` (v2.1.0 — draft must
+  validate against this on schema-typed fields; token strings are accepted
+  where the field type is string or string-array)
 - `valesco-platform/afk/protected-paths/default.yml` (the hard-floor manifest)
+- `valesco-platform/afk/protected-paths/bootstrap-allowlist.yml` (paths a
+  bootstrap contract may legally pre-existing-touch)
+- `valesco-platform/docs/afk/governance-plan.md` §G14 (bootstrap-mode rationale)

--- a/skills/draft-contract/authority-fields.md
+++ b/skills/draft-contract/authority-fields.md
@@ -2,7 +2,7 @@
 
 Reference for `/draft-contract`. Lists every field that carries execution
 authority in a goal contract, classifies whether it can be mechanically
-derived from a Linear issue, and provides the exact `<PLANNER_SUGGESTED:>`
+derived from a tracker issue, and provides the exact `<PLANNER_SUGGESTED:>`
 token copy to emit when it can't.
 
 Fields not listed here are either informational (e.g., `metadata.created`)
@@ -16,37 +16,49 @@ These come directly from skill inputs. No tokens.
 
 | Field | Source |
 |---|---|
-| `schemaVersion` | Constant `"1.0.0"` |
-| `metadata.linearIssueId` | Skill argument |
+| `schemaVersion` | Constant `"2.1.0"` (was `"1.0.0"` pre-v2 — the v1→v2 rename also moved `metadata.linearIssueId` → `metadata.trackerIssueId`; v2.0.0→v2.1.0 added `metadata.bootstrap` and the bootstrap-mode anchors / canary relaxation) |
+| `metadata.trackerIssueId` | Skill argument (Linear: `TEAM-NNN`; GitHub: `owner/repo#NNN`) |
 | `metadata.created` | `new Date().toISOString()` at draft time |
 
-## Derivable from Linear body, token on miss
+## Derivable from tracker body, token on miss
 
-Lift from Linear. If the section is absent, emit the token below — do **not**
-leave the field empty.
+Lift from the tracker issue. If the section is absent, emit the token
+below — do **not** leave the field empty.
 
-| Field | Linear source | Token when missing |
+| Field | Tracker source | Token when missing |
 |---|---|---|
 | `intent.description` | Body before first `##` header, or whole body truncated to ~500 chars | `<PLANNER_SUGGESTED: describe the durable intent in 2-4 sentences; avoid file paths>` |
 | `intent.successCriteria` | Bullets under `## Acceptance` / `## Success criteria` / `## Test plan` | `<PLANNER_SUGGESTED: list the observable conditions that mean this is done, one per bullet>` |
 | `intent.nonGoals` | Bullets under `## Non-goals` / `## Out of scope` | Omit the field entirely if no source bullets; it is optional per schema |
-| `intent.anchors.docs[]` | URLs in body pointing at `.md`, `docs/`, or external doc hosts (Notion, Sanity, Obsidian, Linear Docs) | Empty array if none found; do not emit a token for absence |
-| `terminationConditions` | Usually not stated in Linear — emit token | `<PLANNER_SUGGESTED: list the conditions that end the run successfully, e.g. 'CI green', 'Validator pass', 'pnpm test passes'>` |
+| `intent.anchors.docs[]` | URLs in body pointing at `.md`, `docs/`, or external doc hosts (Notion, Sanity, Obsidian, tracker-native docs) | Empty array if none found; do not emit a token for absence |
+| `terminationConditions` | Usually not stated in the issue body — emit token | `<PLANNER_SUGGESTED: list the conditions that end the run successfully, e.g. 'CI green', 'Validator pass', 'pnpm test passes'>` |
 
 ## Token-required when not derivable
 
-Never mechanically derivable from a Linear issue. The skill always emits the
-token; the human replaces it.
+Never mechanically derivable from a tracker issue. The skill always emits
+the token; the human replaces it.
 
 | Field | Token copy |
 |---|---|
-| `intent.anchors.interfaces[]` | `<PLANNER_SUGGESTED: list TypeScript interfaces or types the contract references; empty array if truly none>` |
-| `intent.anchors.configShapes[]` | `<PLANNER_SUGGESTED: list config objects (e.g. OAuthConfig, SupabaseConfig) the contract depends on; empty array if none>` |
-| `scope.requiredPaths[]` | `<PLANNER_SUGGESTED: globs the agent is expected to touch; these must match real files at pre-flight. For migration contracts, supabase/migrations/** goes here, NOT merely in writePaths.>` |
+| `intent.anchors.interfaces[]` *(forbidden under bootstrap)* | `<PLANNER_SUGGESTED: list TypeScript interfaces or types the contract references; empty array if truly none>` |
+| `intent.anchors.configShapes[]` *(forbidden under bootstrap)* | `<PLANNER_SUGGESTED: list config objects (e.g. OAuthConfig, SupabaseConfig) the contract depends on; empty array if none>` |
+| `scope.requiredPaths[]` | `<PLANNER_SUGGESTED: globs the agent is expected to touch. Standard variant: each glob must match real files at pre-flight. For migration contracts, supabase/migrations/** goes here, NOT merely in writePaths. Bootstrap variant: each glob may resolve to zero files, OR only to entries in afk/protected-paths/bootstrap-allowlist.yml.>` |
 | `scope.writePaths[]` | `<PLANNER_SUGGESTED: globs the agent may modify; must include all requiredPaths. Default hard-floor + escalated-floor paths are never writable via this field.>` |
 | `metadata.customer` (Tier 1 only) | `<PLANNER_SUGGESTED: customer identifier, e.g. acme-corp>` |
-| `canaryPlan.metrics[]` (Tier 1 only) | `<PLANNER_SUGGESTED: metrics to watch post-merge, e.g. error_rate, p95_latency>` |
-| `canaryPlan.rollbackTrigger` (Tier 1 only) | `<PLANNER_SUGGESTED: command or Vercel action to execute on rollback>` |
+| `canaryPlan.metrics[]` (Tier 1 only, optional under bootstrap) | `<PLANNER_SUGGESTED: metrics to watch post-merge, e.g. error_rate, p95_latency>` |
+| `canaryPlan.rollbackTrigger` (Tier 1 only, optional under bootstrap) | `<PLANNER_SUGGESTED: command or Vercel action to execute on rollback>` |
+
+## Bootstrap-mode authority field
+
+Added at schemaVersion 2.1.0. Carries execution authority — flipping it
+between draft and attestation invalidates approval via `contractHash`
+(governance §G14). The skill never sets it silently; it asks the human
+when the foundation-slice heuristic in [`SKILL.md`](./SKILL.md) Step 2.5
+fires.
+
+| Field | Default | Notes |
+|---|---|---|
+| `metadata.bootstrap` | `false` (key omitted) | Set to `true` ONLY when the contract's `requiredPaths` target files that do not yet exist on the resolved tree, OR resolve only to entries in `afk/protected-paths/bootstrap-allowlist.yml`. Re-attestation is required if this value changes. When `true`: omit `intent.anchors.interfaces` and `intent.anchors.configShapes` entirely; `canaryPlan` becomes optional even at Tier 1. |
 
 ## Defaults with suggestion intent
 
@@ -73,8 +85,13 @@ Regardless of source, the skill **must** ensure:
 1. Every authority-bearing field either holds a real value or contains the
    literal string `<PLANNER_SUGGESTED:`. No nulls, no empty strings, no
    empty arrays unless the schema explicitly allows it.
-2. `metadata.linearIssueId` matches `^[A-Z]{2,6}-\d+$`.
+2. `metadata.trackerIssueId` matches the active adapter's identifier
+   format (Linear: `^[A-Z]{2,6}-\d+$`; GitHub: `^[\w.-]+/[\w.-]+#\d+$`).
 3. The file path ends with `.goal-contract.draft.yml` — never
    `.goal-contract.yml`.
 4. Default values carry the `# PLANNER_SUGGESTED` YAML comment so a human
    does not mistake them for derived values.
+5. Under `metadata.bootstrap: true` the keys
+   `intent.anchors.interfaces` and `intent.anchors.configShapes` are
+   **absent** (not present-but-empty) — the v2.1.0 schema forbids them
+   under bootstrap.

--- a/skills/draft-contract/template.yml
+++ b/skills/draft-contract/template.yml
@@ -1,17 +1,31 @@
 # .goal-contract.draft.yml
-# Authored by /draft-contract from Linear issue <LINEAR_ID>.
+# Authored by /draft-contract from tracker issue <TRACKER_ID>.
 # This draft is NON-EXECUTABLE until every <PLANNER_SUGGESTED:> token is replaced
 # and the file is renamed to .goal-contract.yml.
 #
 # Pre-flight hard-rejects any .goal-contract.yml containing a
 # <PLANNER_SUGGESTED:> token per governance plan G8.
+#
+# Two variants live in this template, keyed on metadata.bootstrap:
+#   - Standard variant (default, metadata.bootstrap absent or false): every
+#     glob in scope.requiredPaths must resolve to ≥1 file at pre-flight, and
+#     intent.anchors.interfaces / configShapes are populated.
+#   - Bootstrap variant (metadata.bootstrap: true, foundation slices only):
+#     globs intentionally resolve to zero files (or only to entries in
+#     afk/protected-paths/bootstrap-allowlist.yml), anchors-interfaces and
+#     configShapes are FORBIDDEN by schema, canaryPlan is optional even at
+#     Tier 1. See valesco-platform docs/afk/governance-plan.md §G14.
 
-schemaVersion: "1.0.0"
+schemaVersion: "2.1.0"
 
 metadata:
-  linearIssueId: "<LINEAR_ID>"       # populated from skill argument
-  tier: 3                             # PLANNER_SUGGESTED: default; raise to 2/1 per risk
-  created: "<ISO_TIMESTAMP>"          # populated by skill
+  trackerIssueId: "<TRACKER_ID>"      # populated from skill argument; was linearIssueId pre-v2
+  tier: 3                              # PLANNER_SUGGESTED: default; raise to 2/1 per risk
+  created: "<ISO_TIMESTAMP>"           # populated by skill
+  # bootstrap: false                   # PLANNER_SUGGESTED: set true ONLY for foundation-slice
+                                       # contracts where requiredPaths target files that do not
+                                       # yet exist on the resolved tree. Authority-bearing per
+                                       # G14 — flipping it invalidates approval via contractHash.
   # approvedAt: populated at afk-ready label time; leave unset in draft
   # contractHash: populated by pre-flight after normalization; leave unset in draft
   # customer: REQUIRED when tier is 1. Uncomment and fill.
@@ -19,24 +33,27 @@ metadata:
 
 intent:
   description: |
-    <INTENT_DESCRIPTION_FROM_LINEAR>
+    <INTENT_DESCRIPTION_FROM_TRACKER>
   successCriteria:
-    - <SUCCESS_CRITERIA_FROM_LINEAR>
-  # nonGoals is optional per schema; include when the Linear issue has them
+    - <SUCCESS_CRITERIA_FROM_TRACKER>
+  # nonGoals is optional per schema; include when the tracker issue has them
   nonGoals:
-    - <NON_GOALS_FROM_LINEAR>
+    - <NON_GOALS_FROM_TRACKER>
   anchors:
+    # interfaces / configShapes are FORBIDDEN under metadata.bootstrap: true
+    # (no codebase to anchor to). Omit both keys entirely in the bootstrap
+    # variant; populate them in the standard variant.
     interfaces:
-      - "<PLANNER_SUGGESTED: list TypeScript interfaces or types the contract references; empty array if truly none>"
+      - "<PLANNER_SUGGESTED: list TypeScript interfaces or types the contract references; empty array if truly none. OMIT this key entirely under bootstrap.>"
     configShapes:
-      - "<PLANNER_SUGGESTED: list config objects (e.g. OAuthConfig, SupabaseConfig) the contract depends on; empty array if none>"
+      - "<PLANNER_SUGGESTED: list config objects (e.g. OAuthConfig, SupabaseConfig) the contract depends on; empty array if none. OMIT this key entirely under bootstrap.>"
     docs: []
-      # Populated from Linear-body URLs pointing at docs/ADR/PRD paths.
+      # Populated from tracker-body URLs pointing at docs/ADR/PRD paths.
       # Each entry: { url, versionHash, description? }. See schema.
 
 scope:
   requiredPaths:
-    - "<PLANNER_SUGGESTED: globs the agent is expected to touch; these must match real files at pre-flight. For migration contracts, supabase/migrations/** goes here, NOT merely in writePaths.>"
+    - "<PLANNER_SUGGESTED: globs the agent is expected to touch. Standard variant: each glob must match real files at pre-flight. For migration contracts, supabase/migrations/** goes here, NOT merely in writePaths. Bootstrap variant: each glob may resolve to zero files, OR only to entries in afk/protected-paths/bootstrap-allowlist.yml.>"
   writePaths:
     - "<PLANNER_SUGGESTED: globs the agent may modify; must include all requiredPaths. Default hard-floor + escalated-floor paths are never writable via this field.>"
   # protectedPaths is additive on top of the default floor. Leave unset unless
@@ -56,9 +73,11 @@ budget:
   # costEstimateUsd is populated by pre-flight — leave unset.
 
 terminationConditions:
-  - <TERMINATION_FROM_LINEAR_OR_TOKEN>
+  - <TERMINATION_FROM_TRACKER_OR_TOKEN>
 
-# canaryPlan is REQUIRED when metadata.tier is 1. Uncomment and author:
+# canaryPlan is REQUIRED when metadata.tier is 1 AND metadata.bootstrap !== true.
+# Under metadata.bootstrap: true the v2.1.0 schema relaxes this to optional even
+# at Tier 1 (no production traffic to canary against on a green-field repo).
 # canaryPlan:
 #   metrics:
 #     - "<PLANNER_SUGGESTED: e.g. error_rate, p95_latency>"

--- a/skills/feedback-loop/SKILL.md
+++ b/skills/feedback-loop/SKILL.md
@@ -467,5 +467,5 @@ works" is the same as no loop — it pollutes downstream skills with noise.
   catalog; this skill is the expanded reference.
 - `valesco-platform/docs/afk/governance-plan.md` §G10 — Tier-1 verifier
   determinism rule.
-- `valesco-platform/afk/schemas/goal-contract.v1.json` — the
+- `valesco-platform/afk/schemas/goal-contract.v2.json` — the
   `verification.commands` field shape.

--- a/skills/run-attested/SKILL.md
+++ b/skills/run-attested/SKILL.md
@@ -55,9 +55,11 @@ If absent:
 
 ### 2. Attestation record exists
 
-Resolve the issue ID from `metadata.linearIssueId` (or
-`metadata.trackerIssueId` post-Phase B). Look for
-`.afk/attestations/<id>.json`. If absent:
+Resolve the issue ID from `metadata.trackerIssueId` (renamed from
+`metadata.linearIssueId` at schemaVersion 2.0.0; pre-2.0.0 contracts
+still in flight should also be checked under the legacy field name for
+backward compatibility). Look for `.afk/attestations/<id>.json`. If
+absent:
 
 > Refusing to run. No attestation record at
 > `.afk/attestations/<id>.json`. Run `/attest` first; the runner refuses
@@ -150,6 +152,20 @@ refused) and surface key fields:
 - `reasons` — list as bullets
 - `phase`
 - `contract.tier`
+- `contract.bootstrap` — when `true`, prefix the report with
+  `bootstrap-mode contract` so the human reviewing the branch knows the
+  glob-resolution check was inverted, the canary plan was relaxed, and
+  the friction-delay matrix used the bootstrap row (per VA-327 / VA-329
+  / governance §G14).
+- `preflight.bootstrap_allowlist_hits[]` — when present and non-empty,
+  list each hit. These are pre-existing paths the bootstrap contract is
+  legitimately allowed to touch via
+  `afk/protected-paths/bootstrap-allowlist.yml`. Surface for visibility;
+  do not flag them as drift.
+- `signals.path_facts.bootstrapAllowlistHits[]` — same list as observed
+  through the path-facts signal lens. If it disagrees with
+  `preflight.bootstrap_allowlist_hits[]`, surface the discrepancy
+  prominently — that's a bug in pre-flight or in the audit emitter.
 
 Plus from the runner's stdout JSON:
 

--- a/skills/tracker-github/SKILL.md
+++ b/skills/tracker-github/SKILL.md
@@ -16,13 +16,15 @@ is loaded in the session (`mcp__plugin_engineering_github__*`), prefer
 its typed calls — they're faster and better-typed than `gh` for bulk
 queries. Use `gh` as the universal floor.
 
-## Phase B blocker — read this first
+## Phase B status — full chain unblocked
 
-Until `valesco-platform`'s schema v2 migration lands, the full AFK
-chain through `/draft-contract` and `/attest` will reject GitHub issue
-IDs at schema validation. The contract field `metadata.linearIssueId`
-has regex `^[A-Z]{2,6}-\d+$` — GitHub's `owner/repo#NNN` doesn't
-match.
+The Phase B v2 schema migration in `valesco-platform`
+([#40](https://github.com/ValescoAgency/valesco-platform/pull/40),
+[#68](https://github.com/ValescoAgency/valesco-platform/pull/68))
+renamed `metadata.linearIssueId` → `metadata.trackerIssueId` and
+relaxed the regex to accept the GitHub-shaped `owner/repo#NNN` form
+alongside Linear's `TEAM-NNN`. As of schemaVersion 2.0.0, the full AFK
+chain runs end-to-end against either tracker.
 
 What works today against GitHub:
 
@@ -30,13 +32,11 @@ What works today against GitHub:
   comments, OOS knowledge base, the full triage funnel)
 - `/diagnose` end-to-end (no schema dependencies)
 - `/feedback-loop` (no tracker dependencies)
-
-What does **not** work until Phase B lands:
-
-- `/draft-contract` (rejects the GitHub-shaped ID at schema validation)
-- `/attest` (depends on the contract being valid)
-- `/brief-to-contract` (orchestrates the above; will halt at the draft
-  step)
+- `/draft-contract` end-to-end (writes `metadata.trackerIssueId` with
+  the GitHub-shaped ID; v2.1.0 schema accepts it)
+- `/attest` end-to-end (record key is the GitHub-shaped ID)
+- `/brief-to-contract` end-to-end (orchestration spine routes through
+  the above)
 
 The constraint is intentional and registered in
 [`docs/refactor-plan.md`](../../docs/refactor-plan.md). Phase A1 (rename
@@ -239,10 +239,10 @@ catches a violation, file a bug against this adapter.
 ## What this adapter does NOT do
 
 - **No goal-contract knowledge.** The schema field
-  `metadata.linearIssueId` (its name unchanged in this rollout)
-  belongs to consumer skills and to `valesco-platform`'s schemas.
-  This adapter just provides the issue ID; the GitHub-shaped ID will
-  fail the existing regex until Phase B.
+  `metadata.trackerIssueId` (renamed from `linearIssueId` at
+  schemaVersion 2.0.0) belongs to consumer skills and to
+  `valesco-platform`'s schemas. This adapter just provides the issue
+  ID; the GitHub-shaped form is accepted by the v2 regex.
 - **No tier inference from GitHub metadata.** Tier comes from
   `.afk/config.yml`. (`projectTier: 1` repos using GitHub will
   trigger Tier 1 even though GitHub has no `customer_field` —

--- a/skills/tracker-linear/SKILL.md
+++ b/skills/tracker-linear/SKILL.md
@@ -100,13 +100,14 @@ Linear issue IDs are `<TEAM>-<N>` — e.g., `VA-87`, `MREG-12`.
 The pattern `^[A-Z]{2,6}-\d+$` matches.
 
 This format is also the value `draft-contract` writes into
-`metadata.linearIssueId` and the value `attest` uses as the filename
-for `.afk/attestations/<linearIssueId>.json`. The schema field name
-`linearIssueId` is unchanged in this rollout — it will be renamed to
-`trackerIssueId` only when the Phase B v2 schema migration in
-`valesco-platform` lands. Until then, this adapter populates that field
-with Linear's native ID format and the GitHub adapter (when authored)
-will not be able to drive the full chain past `/draft-contract`.
+`metadata.trackerIssueId` and the value `attest` uses as the filename
+for `.afk/attestations/<trackerIssueId>.json`. The schema field was
+named `linearIssueId` pre-schemaVersion 2.0.0; the v1→v2 migration in
+`valesco-platform` (PRs [#40](https://github.com/ValescoAgency/valesco-platform/pull/40)
+and [#68](https://github.com/ValescoAgency/valesco-platform/pull/68))
+renamed it to `trackerIssueId` and unblocked the GitHub adapter for the
+full chain. This adapter continues to populate the field with Linear's
+native ID format.
 
 ## Linear MCP cheatsheet
 
@@ -141,7 +142,7 @@ against this adapter.
 ## What this adapter does NOT do
 
 - **No goal-contract knowledge.** Schema field names like
-  `linearIssueId` belong to consumer skills (and to
+  `trackerIssueId` belong to consumer skills (and to
   `valesco-platform`'s schemas). The adapter just provides the issue
   ID; the consumer wraps it in whatever schema field is appropriate.
 - **No tier inference.** Tier is read from `.afk/config.yml`, not

--- a/skills/triage/AGENT-BRIEF.md
+++ b/skills/triage/AGENT-BRIEF.md
@@ -6,7 +6,7 @@ Pre-flight will reject a contract whose source brief is vague. So this format is
 
 ## How the brief maps to the goal-contract
 
-(Schema reference: `valesco-platform/afk/schemas/goal-contract.v1.json`. Fields below quote the schema.)
+(Schema reference: `valesco-platform/afk/schemas/goal-contract.v2.json`. Fields below quote the schema.)
 
 | Brief section            | Goal-contract field                          | Pre-flight rule                                       |
 | ------------------------ | -------------------------------------------- | ----------------------------------------------------- |


### PR DESCRIPTION
Fixes [VA-331](https://linear.app/valescoagency/issue/VA-331).

## Summary

- **Bootstrap-mode awareness** (governance §G14) — `/draft-contract`,
  `/attest`, `/brief-to-contract`, and `/run-attested` now understand
  the bootstrap variant: `metadata.bootstrap: true` contracts where
  `requiredPaths` target files that don't yet exist on the resolved
  tree, anchors-interfaces and configShapes are forbidden, and Tier 1
  canary plans are optional.
- **Schema catchup** — every reference in skills/ moves from
  `goal-contract.v1.json` / `metadata.linearIssueId` to v2.1.0 /
  `metadata.trackerIssueId` (the rename that landed upstream in
  ValescoAgency/valesco-platform#40 and #68). Closes the
  documented Phase B blocker for the GitHub adapter.
- **Plugin** bumped 0.4.1 → 0.5.0.

## Scope detail

**Primary (the 6 files VA-331 named):**

| File | Change |
|---|---|
| `skills/draft-contract/template.yml` | v2.1.0 + trackerIssueId + bootstrap-variant comments |
| `skills/draft-contract/SKILL.md` | Step 2.5 foundation-slice detection, refreshed self-validation |
| `skills/draft-contract/authority-fields.md` | New `metadata.bootstrap` authority section + new invariant 5 |
| `skills/attest/checklist.md` | Bootstrap row in delay matrix, `applies` on `canary-plan-sensible`, new `bootstrap-claim-self-verifying` item, `intent-matches-linear` → `intent-matches-tracker` |
| `skills/brief-to-contract/state-machine.md` | Advisory bootstrap signal in Stage-4 tier prompt |
| `skills/run-attested/SKILL.md` | Surfaces `contract.bootstrap`, `preflight.bootstrap_allowlist_hits`, `signals.path_facts.bootstrapAllowlistHits` |

**Necessary ripple from the field rename:**

- `skills/attest/{SKILL.md,record-reference.md}` — incl. new Tier 1 bootstrap example record
- `skills/brief-to-contract/SKILL.md` — path-variable rename
- `skills/tracker-linear/SKILL.md` — note updated to reflect Phase B closure
- `skills/tracker-github/SKILL.md` — Phase B section rewritten; GitHub adapter is now full-capability
- `skills/triage/AGENT-BRIEF.md`, `skills/feedback-loop/SKILL.md` — schema reference v1 → v2

## Out of scope (deliberately not touched)

- `docs/refactor-plan.md` and `docs/gaps.md` still describe Phase B as
  pending. Those forward-looking planning docs need a separate sweep
  once VA-331 lands; updating them would expand this PR beyond the
  explicit scope.
- `docs/adr/0001-tracker-adapter-contract.md` references the pre-rename
  field — ADRs are historical records and stay as-authored.
- The valesco-platform PR template (`afk-scope.md`) is tracked under
  [VA-332](https://linear.app/valescoagency/issue/VA-332) and lives in
  the platform repo.

## Test plan

- [ ] Locally drive `/draft-contract VA-331` against this repo and
      verify the emitted draft has `schemaVersion: "2.1.0"` and
      `metadata.trackerIssueId`
- [ ] Drive `/draft-contract` against a synthetic foundation-slice
      issue (e.g. "scaffold a new Next.js repo") in an empty repo and
      verify the bootstrap variant emits with `metadata.bootstrap: true`,
      no `intent.anchors.interfaces`/`configShapes`, optional canary
- [ ] Drive `/attest` against a Tier 1 bootstrap contract and verify
      `bootstrap-claim-self-verifying` is rendered and tickable, and
      `canary-plan-sensible` is skipped via its `applies` clause
- [ ] Drive `/attest` against a normal Tier 3 contract and verify the
      checklist matches the prior set (minus the renamed
      `intent-matches-tracker` item id)
- [ ] Re-validate that `goal-contract.v2.json` (v2.1.0) accepts the
      drafts produced by both runs above, against the schema in
      valesco-platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)