### PR TITLE
chore(docs): close out Phase B references

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flightplan",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Valesco-authored Claude Code skills for harness engineering and agent orchestration around the AFK autonomous-coding governance pipeline. Vendor-agnostic via the tracker adapter contract — ships with Linear and GitHub Issues adapters at full capability against goal-contract schemaVersion 2.1.0. Bundles the orchestration spine (/brief-to-contract), harness skills (/diagnose, /feedback-loop), tracker funnel (/triage), goal-contract drafting (/draft-contract), tier-scaled attestation (/attest), and v1 dogfood runner (/run-attested). User-invoked, advisory skills only — pipeline code (validators, pre-flight, audit, label handler) lives in valesco-platform per the skills-vs-pipeline rule.",
   "author": {
     "name": "Valesco Agency",

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -103,26 +103,30 @@ belong in `valesco-platform/afk/`.
   produces audit records that flow into the label handler. Hash-bound.
 - **Tracking**: none yet — research item.
 
-### Schema v2: `linearIssueId` → `trackerIssueId` (Phase B)
-
-- **Purpose**: Rename `metadata.linearIssueId` → `metadata.trackerIssueId`
-  in `goal-contract.v1.json` and `attestation-record.v1.json`; broaden
-  the ID regex from `^[A-Z]{2,6}-\d+$` to also accept GitHub-style
-  `owner/repo#NNN` and arbitrary string IDs that satisfy a length floor.
-  Update label handler to read v2. Migrate any in-flight records.
-- **Why pipeline**: Schema authority + label handler logic.
-- **Trigger**: Real demand for AFK chains on non-Linear repos. Don't
-  ship preemptively — the migration cost is real, and it's
-  governance-bound. See
-  [`refactor-plan.md`](./refactor-plan.md#phase-b--schema-v2-in-valesco-platform).
-- **Tracking**: TBD — open in `valesco-platform` when needed.
-- **Phase A3 cleanup**: once Phase B lands, sweep skills to use the new
-  field name (`attest`'s filename pattern, `state-machine.md` rules,
-  prose).
-
 ---
 
 ## Closed gaps
+
+### Schema v2 + Phase A3 sweep — shipped 2026-05-07
+
+- **Ships** (valesco-platform): `goal-contract.v2.json` and
+  `attestation-record.v2.json` with `metadata.trackerIssueId` (replacing
+  `metadata.linearIssueId`); ID regex broadened to accept GitHub-style
+  `owner/repo#NNN`. Label handler reads v2. Schema bumped again to
+  v2.1.0 to add bootstrap-mode (governance §G14) for foundation-slice
+  contracts on green-field repos.
+- **Ships** (flightplan): `linearIssueId` → `trackerIssueId` swept
+  across skills (`attest/`, `draft-contract/template.yml`,
+  `state-machine.md`, prose, examples); skills set `schemaVersion:
+  "2.1.0"` and surface the bootstrap fields. This collapsed Phases B
+  and A3 into one PR.
+- **Tracking**: [VA-331](https://linear.app/valescoagency/issue/VA-331)
+  (flightplan PR #22); valesco-platform PR #40 (schema v2) + PR #68
+  (bootstrap-mode v2.1.0).
+- **Notes**: The full AFK chain through `/draft-contract` and downstream
+  now accepts both Linear-style (`VA-123`) and GitHub-style
+  (`owner/repo#NNN`) IDs. The Phase A2 GitHub adapter is full-capability
+  as a result.
 
 ### `tracker-github` adapter (Phase A2) — shipped 2026-05-01
 
@@ -141,10 +145,10 @@ belong in `valesco-platform/afk/`.
 - **Active-work detection**: heuristic — open issue + (linked PR via
   timeline OR has assignee). `/triage` warns but doesn't refuse on
   best-effort detection.
-- **Constraint** (still open): the full AFK chain through
+- **Constraint** (resolved 2026-05-07): ~~the full AFK chain through
   `/draft-contract` and downstream rejects GitHub-shaped IDs
-  (`owner/repo#NNN`) at schema validation. `/triage` works
-  end-to-end against GitHub today; the rest waits on Phase B.
+  (`owner/repo#NNN`) at schema validation.~~ Phase B shipped in
+  VA-331; the GitHub adapter is now full-capability end-to-end.
 - **Validation milestone**: walk one real low-priority GitHub-Issues
   repo through `/triage` end-to-end before declaring this
   battle-tested. The `flightplan` repo itself is a fine first
@@ -160,7 +164,8 @@ belong in `valesco-platform/afk/`.
   PR A1 (this PR — implementation).
 - **Notes**: Phase A1 of the rollout in
   [`refactor-plan.md`](./refactor-plan.md). Phase A2 (`tracker-github`)
-  registered above; Phase B (schema migration) registered above.
+  registered above; Phase B (schema migration) shipped 2026-05-07 in
+  VA-331 — see "Schema v2 + Phase A3 sweep" below.
   Capabilities baseline: `customer_field`, `project_membership`,
   `cycle_membership`, `team_namespace`, `active_work_detection`.
 
@@ -221,8 +226,9 @@ belong in `valesco-platform/afk/`.
 - **Tracking**: [VA-160](https://linear.app/valescoagency/issue/VA-160).
 - **Notes**: Schema lives in `valesco-platform`
   ([VA-160](https://github.com/ValescoAgency/valesco-platform/pull/31)).
-  Records keyed by `linearIssueId`; `attestedContentSha` is raw-bytes
-  sha. The label handler re-computes and rejects on drift.
+  Records keyed by `trackerIssueId` (post-VA-331; previously
+  `linearIssueId` in v1); `attestedContentSha` is raw-bytes sha. The
+  label handler re-computes and rejects on drift.
 
 ### `/draft-contract` — shipped 2026-04-22
 

--- a/docs/refactor-plan.md
+++ b/docs/refactor-plan.md
@@ -12,8 +12,8 @@ and future vendors.
 |---|---|---|---|---|
 | **A1** | flightplan | Rename + Linear adapter extraction + ADR + CONTEXT.md | nothing | next |
 | **A2** | flightplan | `tracker-github` proof-of-concept (triage-only end-to-end) | A1 | follow-up |
-| **B** | valesco-platform | Schema v2: `linearIssueId` → `trackerIssueId`, regex broadening, label-handler update | independent of A | when GitHub AFK chain is real demand |
-| **A3** | flightplan | Skill sweep to use `trackerIssueId` (post-Phase B) | A1, B | post-B |
+| **B** | valesco-platform | Schema v2: `linearIssueId` → `trackerIssueId`, regex broadening, label-handler update | independent of A | ✅ shipped 2026-05-07 (VA-331; valesco-platform PR #40 + #68) |
+| **A3** | flightplan | Skill sweep to use `trackerIssueId` (post-Phase B) | A1, B | ✅ shipped 2026-05-07 (VA-331) |
 
 A1 and B can run in parallel. A2 depends on A1. A3 depends on both.
 
@@ -84,16 +84,23 @@ A1 and B can run in parallel. A2 depends on A1. A3 depends on both.
   end-to-end as the validation milestone.
 - Doc updates: starter-set, gaps register, workflow.md.
 
-**Known constraint** (acknowledged, documented):
+**Known constraint** (resolved by Phase B, 2026-05-07):
 
-- The full chain `/triage` → `/draft-contract` → `/attest` will reject
-  GitHub issue IDs at schema validation until Phase B lands. The
-  `tracker-github/SKILL.md` calls this out explicitly so users don't
-  hit the wall unprepared.
+- ~~The full chain `/triage` → `/draft-contract` → `/attest` will reject
+  GitHub issue IDs at schema validation until Phase B lands.~~ Phase B
+  shipped in VA-331; the schema now accepts both Linear-style and
+  GitHub-style IDs and the GitHub adapter is full-capability.
 
 ---
 
 ## Phase B — Schema v2 in `valesco-platform`
+
+> ✅ **Shipped 2026-05-07** in VA-331 (valesco-platform PR #40 + #68).
+> Schema bumped to v2.1.0 (the v2.0.0 rename plus a v2.1.0 bootstrap-mode
+> addition per governance §G14). The flightplan-side catchup —
+> `metadata.linearIssueId` → `metadata.trackerIssueId` across skills,
+> templates, and prose — landed in the same VA-331 PR, completing
+> Phase A3. The section below is preserved as historical context.
 
 **Repo**: `valesco-platform`. **Branch**: TBD when the work starts.
 
@@ -123,6 +130,12 @@ governance-bound.
 
 ## Phase A3 — Skill sweep post-Phase B
 
+> ✅ **Shipped 2026-05-07** in VA-331. The `linearIssueId` →
+> `trackerIssueId` sweep across flightplan skills (templates,
+> `attest/`, `state-machine.md`, prose, examples) landed in the same
+> PR as Phase B's flightplan-side catchup. The section below is
+> preserved as historical context.
+
 **Branch**: `chore/trackerIssueId-sweep`
 
 **Ships**:
@@ -149,7 +162,7 @@ governance-bound.
 |---|---|
 | Capability checks forgotten in consumer skills, leading to vendor-specific assumptions creeping back in | A1 includes an explicit capability-check pattern in each consumer skill; review checklist in PR description. |
 | Adapter prose drifts from operations contract over time | ADR-0001 is canonical; adapters reference back to it. Schema-typed contract (Option 2 from grilling) remains a future option if drift becomes a problem. |
-| Phase B never happens, A2 ships and confuses users at the `draft-contract` step | A2's `tracker-github/SKILL.md` documents the Phase B blocker explicitly; `/draft-contract` error message points at the gap. |
+| ~~Phase B never happens, A2 ships and confuses users at the `draft-contract` step~~ | ~~A2's `tracker-github/SKILL.md` documents the Phase B blocker explicitly; `/draft-contract` error message points at the gap.~~ Resolved 2026-05-07 — Phase B shipped in VA-331; `/draft-contract` accepts both Linear-style and GitHub-style IDs. |
 | Slash-command rename `/linear-triage` → `/triage` breaks user muscle memory | Plugin version bump (0.2.0 → 0.3.0) signals breaking change; README + starter-set call out the rename; `/linear-triage` removal is documented. |
 
 ## References

--- a/docs/starter-set.md
+++ b/docs/starter-set.md
@@ -36,7 +36,7 @@ Loaded automatically by consumer skills based on `.afk/config.yml`'s
 | Adapter | Status | Notes |
 |---|---|---|
 | [`tracker-linear`](../skills/tracker-linear/SKILL.md) | Shipped (default) | Full capability set. |
-| [`tracker-github`](../skills/tracker-github/SKILL.md) | Shipped (Phase A2) | Triage end-to-end works; full chain blocks on Phase B schema migration. |
+| [`tracker-github`](../skills/tracker-github/SKILL.md) | Shipped (Phase A2) | Full-capability end-to-end post-VA-331 (Phase B schema migration shipped 2026-05-07). |
 | `tracker-jira`, `tracker-local-md` | Deferred | — |
 
 ---

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -146,7 +146,7 @@ only canonical names; the adapter translates to vendor-native form.
 | Adapter | Status | Notes |
 |---|---|---|
 | [`tracker-linear`](../skills/tracker-linear/SKILL.md) | Default, shipped | Full capability set — `customer_field`, `team_namespace`, reliable active-work detection. |
-| [`tracker-github`](../skills/tracker-github/SKILL.md) | Shipped (Phase A2) | Triage-end-to-end works; full chain through `/draft-contract` blocked on Phase B schema migration in `valesco-platform`. |
+| [`tracker-github`](../skills/tracker-github/SKILL.md) | Shipped (Phase A2) | Full-capability end-to-end through `/draft-contract` and `/attest` post-VA-331 (Phase B schema migration shipped 2026-05-07). |
 | `tracker-jira`, `tracker-local-md` | Deferred | — |
 
 The contract that defines the adapter API is


### PR DESCRIPTION
## Summary

- Catches up `docs/refactor-plan.md` and `docs/gaps.md` to reflect that Phase B (schema v1→v2 / `linearIssueId` → `trackerIssueId`) and Phase A3 (the flightplan-side rename sweep) shipped together in VA-331 ([flightplan#22](https://github.com/ValescoAgency/flightplan/pull/22), valesco-platform PR #40 + #68). VA-331 explicitly deferred this docs sweep.
- Also closes the same Phase B blocker language in `docs/workflow.md` and `docs/starter-set.md` (tracker-github status row), since the acceptance criterion was "a new contributor cannot conclude Phase B is still pending" reading any planning doc cold.
- `docs/adr/0001-tracker-adapter-contract.md` deliberately left untouched — ADRs are historical records of the decision at the time.
- Plugin version: `0.5.0` → `0.5.1` (docs-only patch bump).

### Files changed

- `docs/refactor-plan.md` — Phase B and A3 marked ✅ shipped in the at-a-glance table; status banners prepended to both phase sections; Phase A2's "known constraint" and the risk-register row marked resolved.
- `docs/gaps.md` — Schema v2 entry moved from "Cross-reference — pipeline items" to "Closed gaps" with VA-331 / PR #40 + #68 attribution; tracker-github "still open" constraint marked resolved; tracker-adapter + `/attest` closed-gap notes updated.
- `docs/workflow.md`, `docs/starter-set.md` — tracker-github table row no longer describes the full chain as blocked on Phase B.
- `.claude-plugin/plugin.json` — `0.5.0` → `0.5.1`.

## Test plan

- [ ] `git grep -nE "Phase B|linearIssueId|Schema v2" docs/ ':!docs/adr/'` shows only resolved / historical / strikethrough references — nothing describing live work as pending.
- [ ] Read `docs/refactor-plan.md` cold: Phase B and A3 read as shipped; A1/A2 staleness in the at-a-glance table is pre-existing (out of scope here).
- [ ] Read `docs/gaps.md` cold: Schema v2 / Phase B is in **Closed gaps**; tracker-github constraint is resolved; `/attest` notes describe records as keyed by `trackerIssueId`.
- [ ] Plugin version bumped to `0.5.1`.

## Follow-ups (out of scope)

- Pre-existing staleness in `docs/refactor-plan.md`'s at-a-glance table for Phase A1 ("next") and A2 ("follow-up") — both shipped 2026-05-01 per `docs/gaps.md` Closed entries. Worth a separate one-line sweep but not in this PR's scope.
- File a Linear issue retroactively if record-keeping wants one (VA-331 noted this was deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)