### PR TITLE
chore(docs): refresh A1/A2 status in refactor-plan

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flightplan",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Valesco-authored Claude Code skills for harness engineering and agent orchestration around the AFK autonomous-coding governance pipeline. Vendor-agnostic via the tracker adapter contract — ships with Linear and GitHub Issues adapters at full capability against goal-contract schemaVersion 2.1.0. Bundles the orchestration spine (/brief-to-contract), harness skills (/diagnose, /feedback-loop), tracker funnel (/triage), goal-contract drafting (/draft-contract), tier-scaled attestation (/attest), and v1 dogfood runner (/run-attested). User-invoked, advisory skills only — pipeline code (validators, pre-flight, audit, label handler) lives in valesco-platform per the skills-vs-pipeline rule.",
   "author": {
     "name": "Valesco Agency",

--- a/docs/refactor-plan.md
+++ b/docs/refactor-plan.md
@@ -10,8 +10,8 @@ and future vendors.
 
 | Phase | Repo | Scope | Depends on | Status |
 |---|---|---|---|---|
-| **A1** | flightplan | Rename + Linear adapter extraction + ADR + CONTEXT.md | nothing | next |
-| **A2** | flightplan | `tracker-github` proof-of-concept (triage-only end-to-end) | A1 | follow-up |
+| **A1** | flightplan | Rename + Linear adapter extraction + ADR + CONTEXT.md | nothing | ✅ shipped 2026-05-01 (PR #6 + #7) |
+| **A2** | flightplan | `tracker-github` proof-of-concept (triage-only end-to-end) | A1 | ✅ shipped 2026-05-01 (PR #9) |
 | **B** | valesco-platform | Schema v2: `linearIssueId` → `trackerIssueId`, regex broadening, label-handler update | independent of A | ✅ shipped 2026-05-07 (VA-331; valesco-platform PR #40 + #68) |
 | **A3** | flightplan | Skill sweep to use `trackerIssueId` (post-Phase B) | A1, B | ✅ shipped 2026-05-07 (VA-331) |
 


### PR DESCRIPTION
## Summary

- Update [docs/refactor-plan.md](docs/refactor-plan.md) "Phases at a glance" so A1 and A2 reflect that they shipped 2026-05-01 (per [docs/gaps.md](docs/gaps.md) Closed gaps entries). PR #23 just landed B/A3 as shipped, so the table was internally inconsistent (B and A3 done, but their A1/A2 dependencies still listed as "next" / "follow-up").
- A1 → `✅ shipped 2026-05-01 (PR #6 + #7)` — PR #6 landed ADR-0001/CONTEXT/refactor-plan, PR #7 landed the implementation.
- A2 → `✅ shipped 2026-05-01 (PR #9)` — `tracker-github` adapter + dogfood.
- Bump [.claude-plugin/plugin.json](.claude-plugin/plugin.json) `0.5.1` → `0.5.2`.

Phase A1 / A2 prose sections below the table are unchanged — they read fine as historical "what shipped" narrative. ADR-0001 is also untouched.

## Test plan

- [x] `git diff` reviewed: only the two table rows and the version bump are touched
- [x] No struck-through prose, no ADR edits
- [x] Version is exactly one patch ahead of main (`0.5.1` → `0.5.2`)