### PR TITLE
feat(skills): /runway-init — onboard target repos to runway in one pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ the adapter system below.
 | [`/triage`](skills/triage/SKILL.md) | Funnel issues into `Todo` with sharp acceptance criteria so runway will pick them up. HITL-aware. |
 | [`/diagnose`](skills/diagnose/SKILL.md) | Six-phase debugging discipline; Phase 1 builds a deterministic feedback loop. |
 | [`/feedback-loop`](skills/feedback-loop/SKILL.md) | The 10-pattern catalog for constructing deterministic agent-runnable signals. |
+| [`/runway-init`](skills/runway-init/SKILL.md) | Onboard a target repo to runway in one pass — `npx sandcastle init` plus Valesco's varlock + 1Password customizations. Embedded scripts; advisory (commits but never pushes). |
 
 ## Tracker adapters
 

--- a/skills/runway-init/SKILL.md
+++ b/skills/runway-init/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: runway-init
+description: Scaffold a target repo so [runway](https://github.com/ValescoAgency/runway) can drive coding agents against it via [@ai-hero/sandcastle](https://github.com/mattpocock/sandcastle). Wraps `npx sandcastle init` and layers on Valesco's customizations — varlock + 1Password integration, in-container secret resolution, drop-the-`.env` posture. Use when the user wants to onboard a new repo to runway, set up sandcastle in a repo that doesn't have it, or rotate an existing `.sandcastle/` to the secrets-free shape.
+---
+
+# /runway-init — onboard a repo to runway in one pass
+
+The purpose of this skill is to take a clean target repo and leave it
+in the exact shape runway needs:
+
+- `.sandcastle/` (Sandcastle's own scaffold) present
+- `.env.schema` at repo root, with `op://` references the user has
+  confirmed point at real items in their 1Password vault
+- `.sandcastle/Dockerfile` patched to bake in `varlock` + `op` CLI +
+  a `claude` shim so the agent runs inside `varlock run -- claude.real`
+- `.sandcastle/.env` deleted (no secrets at rest)
+- A clean commit on a fresh branch ready for the user to push
+
+Anything more than that is out of scope. This skill is **advisory** —
+it produces a branch + commit, never auto-pushes, never opens a PR.
+
+## When to run
+
+- A target repo has just been created and needs to receive runway runs.
+- An existing target repo predates the varlock customizations and
+  still has secrets in `.sandcastle/.env` or its repo root `.env`.
+- After a major Sandcastle bump that changes the generated Dockerfile
+  template (re-run, re-apply the patch).
+
+## When NOT to run
+
+- The user wants to edit the issue body / triage the inbox → `/triage`.
+- The user wants to debug code or build a feedback loop → `/diagnose`,
+  `/feedback-loop`.
+- The user wants to scaffold runway *itself* (the orchestrator
+  package). runway-init only sets up *target repos* runway will drive.
+- The repo is a control-plane / non-coding repo (docs site, design
+  files). Sandcastle expects a code repo.
+
+## Inputs you must collect from the user up front
+
+Before running any script, confirm these. Don't assume.
+
+1. **Tier choice.** Tier 2 is the recommended path:
+   - **Tier 1** — sandcastle init only, secrets live in `.sandcastle/.env`
+     on disk. Faster to set up, weaker security posture. Use if the user
+     has explicitly opted out of varlock.
+   - **Tier 2** — sandcastle init + varlock + 1Password CLI inside the
+     container. Zero secrets at rest. **Default.**
+2. **1Password vault layout.** For Tier 2 you need to scaffold the
+   `.env.schema` with concrete `op://...` paths. Ask:
+   - Which 1Password account (e.g. `valesco`)?
+   - Which vault (e.g. `runway`, `engineering`)?
+   - Item names for `ANTHROPIC_API_KEY` and `GH_TOKEN` — do they live in
+     a single shared item with multiple fields, or one item per secret?
+3. **Idempotency.** If `.sandcastle/` already exists, ask:
+   - Re-init from scratch (delete and recreate)?
+   - Patch in place (just apply the varlock layer to the existing
+     Dockerfile and re-write `.env.schema`)?
+
+If any of these is unclear, stop and ask. Don't pick defaults silently.
+
+## How to run
+
+The scripts in [`scripts/`](scripts/) are sequenced 00 → 30. Run them
+from the **target repo's root**, not from within flightplan.
+
+| Script | What it does | When to skip |
+|---|---|---|
+| [`00-preflight.sh`](scripts/00-preflight.sh) | Check the host has Docker running, `gh` authenticated, `node` ≥ 22, and (Tier 2 only) `varlock` + `op` installed. Confirm we're inside a clean git tree. | Never. |
+| [`10-sandcastle-init.sh`](scripts/10-sandcastle-init.sh) | `npx sandcastle init`. Creates `.sandcastle/` in the cwd. | If `.sandcastle/` already exists and the user chose patch-in-place. |
+| [`20-apply-varlock.sh`](scripts/20-apply-varlock.sh) | Tier 2 only. Patches `.sandcastle/Dockerfile`, scaffolds `.env.schema` at repo root, deletes `.sandcastle/.env`. Takes vault layout as args. | Skip for Tier 1. |
+| [`30-verify.sh`](scripts/30-verify.sh) | Static checks: `.env.schema` syntactically valid, Dockerfile shim references `varlock`, no plaintext secrets in `.sandcastle/.env`. | Never. |
+
+The skill body is responsible for:
+
+1. Asking the user for the inputs above.
+2. Calling the scripts in order with the right flags.
+3. Showing the user the diff before staging.
+4. Staging on a fresh branch named
+   `chore/runway-init-{epoch-ms}` (no force pushes, no main branch
+   commits).
+5. Committing with this message body:
+
+   ```
+   chore: scaffold for runway via /runway-init
+
+   Tier: <1|2>
+   sandcastle: <version>
+   varlock: <version, Tier 2 only>
+   1Password vault: <account>/<vault>
+
+   Per .claude/skills/runway-init from flightplan.
+   ```
+
+6. Telling the user to push and open a PR. Never push for them.
+
+## Templates this skill ships
+
+Vendored copies of the canonical files from
+[ValescoAgency/runway](https://github.com/ValescoAgency/runway). They
+live in [`templates/`](templates/) so the skill is self-contained
+(works offline, doesn't depend on runway's main being current at the
+moment of invocation).
+
+| Template | Source of truth |
+|---|---|
+| [`templates/env.schema.target-repo`](templates/env.schema.target-repo) | `runway/templates/.env.schema.target-repo` |
+| [`templates/dockerfile-varlock.snippet`](templates/dockerfile-varlock.snippet) | `runway/templates/dockerfile-varlock.snippet` |
+
+When you bump these, also bump
+[`runway/templates/`](https://github.com/ValescoAgency/runway/tree/main/templates).
+Drift between the two is a bug.
+
+## AI disclaimer
+
+The commit message this skill produces does NOT need a "generated by
+AI" disclaimer — the skill name + the commit body identify provenance
+clearly. If the skill posts a comment to a tracker issue (it shouldn't,
+but if it does), the standard disclaimer applies:
+
+```
+> *This was generated by AI during runway-init.*
+```
+
+## What this skill deliberately does NOT do
+
+- **Push or open a PR.** User reviews the diff and ships it themselves.
+- **Touch 1Password.** No `op item create` calls. The user is
+  responsible for putting items in their vault before invoking this
+  skill; we read but don't write.
+- **Validate that secrets exist in 1Password.** If the user gave a
+  nonexistent path, the first runway run will fail informatively. We
+  don't pre-fetch.
+- **Update runway itself.** This skill operates on target repos.
+- **Modify `.github/workflows/`.** Out of scope for runway adoption.
+
+## Gotchas
+
+- Sandcastle's generated Dockerfile uses `ENTRYPOINT ["sleep",
+  "infinity"]` — the agent isn't PID 1, it's `docker exec`'d. That's
+  why our shim approach replaces the `claude` binary in
+  `/home/agent/.local/bin/`. If a future Sandcastle release changes
+  the agent invocation path, the patch in
+  `templates/dockerfile-varlock.snippet` may need updating.
+- The `op` CLI inside the container needs `OP_SERVICE_ACCOUNT_TOKEN` —
+  runway's orchestrator passes that in via Sandcastle's
+  `docker({ env })` option. The user does not need to bake the token
+  into the image.
+- `.env.schema` lives at repo **root**, not under `.sandcastle/`.
+  varlock's convention. Don't move it.
+
+## References
+
+- [runway README](https://github.com/ValescoAgency/runway#readme)
+- [runway secrets-with-varlock walkthrough](https://github.com/ValescoAgency/runway/blob/main/docs/secrets-with-varlock.md)
+- [@ai-hero/sandcastle docs](https://github.com/mattpocock/sandcastle/tree/main/docs)
+- [varlock Docker workflows](https://varlock.dev/llms-full.txt)

--- a/skills/runway-init/scripts/00-preflight.sh
+++ b/skills/runway-init/scripts/00-preflight.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# 00-preflight.sh — verify host environment + repo state before any
+# scaffolding writes. Exits non-zero with a clear message on the first
+# failure. Run from the target repo's root.
+#
+# Usage: 00-preflight.sh --tier=1|2 [--allow-dirty]
+
+set -euo pipefail
+
+TIER=
+ALLOW_DIRTY=0
+for arg in "$@"; do
+  case "$arg" in
+    --tier=1) TIER=1 ;;
+    --tier=2) TIER=2 ;;
+    --allow-dirty) ALLOW_DIRTY=1 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+if [[ -z "$TIER" ]]; then
+  echo "ERROR: --tier=1 or --tier=2 required" >&2
+  exit 2
+fi
+
+fail() { echo "PREFLIGHT FAIL: $*" >&2; exit 1; }
+ok()   { echo "  ✓ $*"; }
+
+echo "[runway-init] preflight (tier $TIER)"
+
+# --- Toolchain ---
+command -v git >/dev/null    || fail "git not on PATH"
+ok "git"
+
+command -v node >/dev/null   || fail "node not on PATH (need ≥ 22)"
+NODE_MAJOR=$(node --version | sed -E 's/^v([0-9]+)\..*/\1/')
+[[ "$NODE_MAJOR" -ge 22 ]] || fail "node ≥ 22 required, found $(node --version)"
+ok "node $(node --version)"
+
+command -v docker >/dev/null || fail "docker not on PATH (Docker Desktop or Podman)"
+docker info >/dev/null 2>&1  || fail "docker daemon not running — start Docker Desktop"
+ok "docker daemon up"
+
+command -v gh >/dev/null     || fail "gh not on PATH"
+gh auth status >/dev/null 2>&1 || fail "gh not authenticated — run \`gh auth login\`"
+ok "gh authenticated"
+
+if [[ "$TIER" == "2" ]]; then
+  command -v varlock >/dev/null || fail "varlock not on PATH (\`brew install varlock\` or \`pnpm add -g varlock\`)"
+  ok "varlock $(varlock --version 2>/dev/null || echo '?')"
+  command -v op >/dev/null      || fail "1Password CLI (\`op\`) not on PATH"
+  ok "op $(op --version 2>/dev/null || echo '?')"
+fi
+
+# --- Repo state ---
+git rev-parse --git-dir >/dev/null 2>&1 || fail "not inside a git repo"
+ok "git repo: $(git rev-parse --show-toplevel)"
+
+if [[ "$ALLOW_DIRTY" == "0" ]] && [[ -n "$(git status --porcelain)" ]]; then
+  fail "working tree is dirty — commit/stash first, or pass --allow-dirty"
+fi
+ok "working tree clean (or --allow-dirty)"
+
+# A brand-new repo with no commits has no HEAD yet — that's fine, the
+# caller will branch + commit later regardless.
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  if [[ "$CURRENT_BRANCH" == "main" ]] || [[ "$CURRENT_BRANCH" == "master" ]]; then
+    echo "  ⚠  on default branch ($CURRENT_BRANCH) — caller must create a feature branch before staging"
+  fi
+else
+  echo "  ⚠  repo has no commits yet — caller will commit on a fresh branch"
+fi
+
+echo "[runway-init] preflight OK"

--- a/skills/runway-init/scripts/10-sandcastle-init.sh
+++ b/skills/runway-init/scripts/10-sandcastle-init.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# 10-sandcastle-init.sh — runs `npx sandcastle init` if .sandcastle/ is
+# missing, otherwise exits with a notice (the SKILL.md is responsible
+# for asking the user whether to overwrite). Run from the target repo
+# root.
+#
+# Usage: 10-sandcastle-init.sh [--force]
+
+set -euo pipefail
+
+FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -d .sandcastle ]]; then
+  if [[ "$FORCE" == "0" ]]; then
+    echo "[runway-init] .sandcastle/ already exists — skipping init"
+    echo "  (pass --force to delete and re-init)"
+    exit 0
+  fi
+  echo "[runway-init] --force given, removing existing .sandcastle/"
+  rm -rf .sandcastle
+fi
+
+echo "[runway-init] running \`npx -y -p @ai-hero/sandcastle@latest sandcastle init\` ..."
+npx -y -p @ai-hero/sandcastle@latest sandcastle init
+
+if [[ ! -d .sandcastle ]]; then
+  echo "ERROR: sandcastle init did not produce .sandcastle/" >&2
+  exit 1
+fi
+
+echo "[runway-init] .sandcastle/ scaffolded:"
+ls -la .sandcastle/

--- a/skills/runway-init/scripts/20-apply-varlock.sh
+++ b/skills/runway-init/scripts/20-apply-varlock.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# 20-apply-varlock.sh — Tier 2 customization layer. Runs after
+# 10-sandcastle-init.sh has produced .sandcastle/. Three changes:
+#
+#   1. Patches .sandcastle/Dockerfile to bake in `varlock` + `op` CLI
+#      and shim the `claude` binary so every invocation runs through
+#      `varlock run -- claude.real`.
+#   2. Scaffolds .env.schema at repo root (varlock convention) with
+#      op:// references for ANTHROPIC_API_KEY + GH_TOKEN. Paths are
+#      filled in from --op-account / --op-vault flags.
+#   3. Deletes .sandcastle/.env and .sandcastle/.env.example so no
+#      secret manifest sits at rest. The repo-root .env.schema is the
+#      sole source of truth.
+#
+# Run from the target repo root.
+#
+# Usage:
+#   20-apply-varlock.sh \
+#       --op-account=valesco \
+#       --op-vault=runway \
+#       --anthropic-item=anthropic-api-key \
+#       --gh-token-item=gh-token \
+#       [--templates-dir=/path/to/skill/templates]
+
+set -euo pipefail
+
+OP_ACCOUNT=
+OP_VAULT=
+ANTHROPIC_ITEM=
+GH_TOKEN_ITEM=
+TEMPLATES_DIR=
+
+for arg in "$@"; do
+  case "$arg" in
+    --op-account=*)     OP_ACCOUNT="${arg#*=}" ;;
+    --op-vault=*)       OP_VAULT="${arg#*=}" ;;
+    --anthropic-item=*) ANTHROPIC_ITEM="${arg#*=}" ;;
+    --gh-token-item=*)  GH_TOKEN_ITEM="${arg#*=}" ;;
+    --templates-dir=*)  TEMPLATES_DIR="${arg#*=}" ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$OP_ACCOUNT" ]]     || { echo "ERROR: --op-account required" >&2; exit 2; }
+[[ -n "$OP_VAULT" ]]       || { echo "ERROR: --op-vault required" >&2; exit 2; }
+[[ -n "$ANTHROPIC_ITEM" ]] || { echo "ERROR: --anthropic-item required" >&2; exit 2; }
+[[ -n "$GH_TOKEN_ITEM" ]]  || { echo "ERROR: --gh-token-item required" >&2; exit 2; }
+
+# Default templates dir is co-located with this script.
+if [[ -z "$TEMPLATES_DIR" ]]; then
+  TEMPLATES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../templates && pwd)"
+fi
+[[ -d "$TEMPLATES_DIR" ]] || { echo "ERROR: templates dir not found: $TEMPLATES_DIR" >&2; exit 1; }
+
+[[ -d .sandcastle ]] || { echo "ERROR: .sandcastle/ missing — run 10-sandcastle-init.sh first" >&2; exit 1; }
+[[ -f .sandcastle/Dockerfile ]] || { echo "ERROR: .sandcastle/Dockerfile missing" >&2; exit 1; }
+
+echo "[runway-init] applying Tier 2 (varlock + 1Password) layer"
+
+# --- 1. .env.schema at repo root ---
+if [[ -f .env.schema ]]; then
+  echo "  ⚠  .env.schema already exists — backing up to .env.schema.bak"
+  cp .env.schema .env.schema.bak
+fi
+
+# Substitute the {{...}} placeholders. Using sed because the template
+# is small + the placeholders are unambiguous.
+sed \
+  -e "s|{{OP_ACCOUNT}}|$OP_ACCOUNT|g" \
+  -e "s|{{OP_VAULT}}|$OP_VAULT|g" \
+  -e "s|{{ANTHROPIC_ITEM}}|$ANTHROPIC_ITEM|g" \
+  -e "s|{{GH_TOKEN_ITEM}}|$GH_TOKEN_ITEM|g" \
+  "$TEMPLATES_DIR/env.schema.target-repo" \
+  > .env.schema
+
+echo "  ✓ wrote .env.schema (op://$OP_ACCOUNT/$OP_VAULT/...)"
+
+# --- 2. Patch Dockerfile ---
+DOCKERFILE=.sandcastle/Dockerfile
+
+# Idempotency: don't double-apply.
+if grep -q 'varlock run --env-file' "$DOCKERFILE"; then
+  echo "  ✓ Dockerfile already patched (idempotent skip)"
+else
+  # Sandcastle's stock Dockerfile ends with:
+  #   ENTRYPOINT ["sleep", "infinity"]
+  # We splice the varlock layer in JUST before that line.
+  if ! grep -q '^ENTRYPOINT \["sleep", "infinity"\]' "$DOCKERFILE"; then
+    echo "ERROR: expected \`ENTRYPOINT [\"sleep\", \"infinity\"]\` line in $DOCKERFILE" >&2
+    echo "  Sandcastle may have changed its template; update templates/dockerfile-varlock.snippet" >&2
+    exit 1
+  fi
+  TMP="$(mktemp)"
+  # Everything up to (but not including) the ENTRYPOINT line:
+  awk '/^ENTRYPOINT \["sleep", "infinity"\]/{exit} {print}' "$DOCKERFILE" > "$TMP"
+  # The varlock snippet:
+  cat "$TEMPLATES_DIR/dockerfile-varlock.snippet" >> "$TMP"
+  echo "" >> "$TMP"
+  # The original ENTRYPOINT line (preserve exact text):
+  grep '^ENTRYPOINT \["sleep", "infinity"\]' "$DOCKERFILE" >> "$TMP"
+  mv "$TMP" "$DOCKERFILE"
+  echo "  ✓ patched $DOCKERFILE (varlock + op CLI + claude shim)"
+fi
+
+# --- 3. Drop .sandcastle/.env (secrets at rest) ---
+for f in .sandcastle/.env .sandcastle/.env.example; do
+  if [[ -f "$f" ]]; then
+    rm "$f"
+    echo "  ✓ removed $f"
+  fi
+done
+
+# --- 4. .gitignore: keep .env.schema.bak out of commits ---
+if [[ -f .gitignore ]] && ! grep -q '^\.env\.schema\.bak$' .gitignore; then
+  echo ".env.schema.bak" >> .gitignore
+  echo "  ✓ appended .env.schema.bak to .gitignore"
+fi
+
+echo "[runway-init] Tier 2 layer applied"

--- a/skills/runway-init/scripts/30-verify.sh
+++ b/skills/runway-init/scripts/30-verify.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# 30-verify.sh — static post-install sanity checks. Runs in cwd of
+# target repo. Exits non-zero if anything's wrong; output explains
+# what to fix.
+#
+# Usage: 30-verify.sh --tier=1|2
+
+set -euo pipefail
+
+TIER=
+for arg in "$@"; do
+  case "$arg" in
+    --tier=1) TIER=1 ;;
+    --tier=2) TIER=2 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+[[ -n "$TIER" ]] || { echo "ERROR: --tier=1 or --tier=2 required" >&2; exit 2; }
+
+fail() { echo "VERIFY FAIL: $*" >&2; exit 1; }
+ok()   { echo "  ✓ $*"; }
+
+echo "[runway-init] verify (tier $TIER)"
+
+# --- Sandcastle scaffold present ---
+[[ -d .sandcastle ]]            || fail ".sandcastle/ missing"
+[[ -f .sandcastle/Dockerfile ]] || fail ".sandcastle/Dockerfile missing"
+ok ".sandcastle/Dockerfile present"
+
+if [[ "$TIER" == "1" ]]; then
+  # Tier 1: .sandcastle/.env.example should exist (sandcastle's normal flow)
+  if [[ ! -f .sandcastle/.env.example ]]; then
+    echo "  ⚠  .sandcastle/.env.example missing — sandcastle init may have failed"
+  else
+    ok ".sandcastle/.env.example present"
+  fi
+  echo "[runway-init] verify OK (tier 1)"
+  exit 0
+fi
+
+# --- Tier 2 only below ---
+
+# .env.schema at repo root ---
+[[ -f .env.schema ]] || fail ".env.schema missing at repo root (Tier 2 requires it)"
+ok ".env.schema present"
+
+# Schema must reference at least the two required vars. Use grep -F to
+# avoid regex pitfalls; the names are fixed.
+grep -qF 'ANTHROPIC_API_KEY=' .env.schema || fail ".env.schema missing ANTHROPIC_API_KEY"
+grep -qF 'GH_TOKEN='          .env.schema || fail ".env.schema missing GH_TOKEN"
+ok ".env.schema declares ANTHROPIC_API_KEY + GH_TOKEN"
+
+# No literal API key values committed (basic shape check, not exhaustive).
+if grep -qE '(sk-ant-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{20,}|lin_api_[A-Za-z0-9]{20,})' .env.schema 2>/dev/null; then
+  fail ".env.schema appears to contain a real secret value — refactor to use op:// references"
+fi
+ok ".env.schema contains no inline secrets"
+
+# Dockerfile patched
+DF=.sandcastle/Dockerfile
+grep -q 'varlock run --env-file' "$DF" || fail "Dockerfile not patched with varlock shim"
+grep -q '/home/agent/.local/bin/claude.real' "$DF" || fail "Dockerfile shim not in expected layout"
+ok "Dockerfile patched with varlock + claude shim"
+
+# .sandcastle/.env should be gone
+if [[ -f .sandcastle/.env ]]; then
+  fail ".sandcastle/.env still on disk — Tier 2 deletes it (file may have been re-created; check sandcastle init flow)"
+fi
+ok ".sandcastle/.env not on disk"
+
+# No file under target repo contains a literal sk-ant- or ghp_ token.
+SECRET_HITS=$(git ls-files -z 2>/dev/null \
+  | xargs -0 grep -lE '(sk-ant-[A-Za-z0-9_-]{20,}|ghp_[A-Za-z0-9]{20,}|lin_api_[A-Za-z0-9]{20,})' 2>/dev/null \
+  | grep -v '^.env.schema$' || true)
+if [[ -n "$SECRET_HITS" ]]; then
+  fail "found literal secret values in tracked files: $SECRET_HITS"
+fi
+ok "no literal secret values in tracked files"
+
+echo "[runway-init] verify OK (tier 2)"

--- a/skills/runway-init/templates/dockerfile-varlock.snippet
+++ b/skills/runway-init/templates/dockerfile-varlock.snippet
@@ -1,0 +1,33 @@
+# =============================================================================
+# Appended by /runway-init (flightplan skill). Do not edit by hand —
+# re-run the skill if you need to refresh.
+# =============================================================================
+
+# Pull the varlock binary from its official image (multi-stage).
+COPY --from=ghcr.io/dmno-dev/varlock:latest /usr/local/bin/varlock /usr/local/bin/varlock
+
+# Install the 1Password CLI so varlock can resolve `op://` references.
+USER root
+RUN curl -sS https://downloads.1password.com/linux/keys/1password.asc \
+      | gpg --dearmor -o /usr/share/keyrings/1password-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" \
+      > /etc/apt/sources.list.d/1password.list \
+  && apt-get update && apt-get install -y 1password-cli \
+  && rm -rf /var/lib/apt/lists/*
+
+# Shim the `claude` binary so every invocation runs through varlock.
+# The real binary moves to claude.real; the shim resolves secrets from
+# 1Password (using OP_SERVICE_ACCOUNT_TOKEN passed in by runway) and
+# execs the real claude with secrets in its process env. Secrets exist
+# only inside the lifetime of one claude invocation — never in any
+# image layer, never on the container filesystem.
+RUN mv /home/agent/.local/bin/claude /home/agent/.local/bin/claude.real \
+  && printf '%s\n' \
+       '#!/usr/bin/env bash' \
+       'set -euo pipefail' \
+       'exec varlock run --env-file /home/agent/workspace/.env.schema -- /home/agent/.local/bin/claude.real "$@"' \
+       > /home/agent/.local/bin/claude \
+  && chmod +x /home/agent/.local/bin/claude \
+  && chown agent:agent /home/agent/.local/bin/claude
+
+USER ${AGENT_UID}:${AGENT_GID}

--- a/skills/runway-init/templates/env.schema.target-repo
+++ b/skills/runway-init/templates/env.schema.target-repo
@@ -1,0 +1,27 @@
+# Per-target-repo secrets manifest. Lives at the target repo root
+# (NOT in .sandcastle/, since that directory is sandcastle's territory).
+#
+# This file is committed. Values resolve at runtime via varlock + the
+# 1Password CLI inside the sandcastle container — see
+# .sandcastle/Dockerfile for the wiring.
+#
+# When the agent runs, the `claude` binary inside the container is a
+# wrapper that invokes `varlock run -- claude.real`. varlock reads
+# THIS file, fetches the op:// references using the OP_SERVICE_ACCOUNT_TOKEN
+# that runway passed in at container start, and exposes the resolved
+# values to the real claude process for the duration of that one
+# invocation. After it exits, secrets are gone from container memory.
+
+# @sensitive @required
+ANTHROPIC_API_KEY=exec('op read "op://{{OP_ACCOUNT}}/{{OP_VAULT}}/{{ANTHROPIC_ITEM}}"')
+
+# @sensitive @required
+GH_TOKEN=exec('op read "op://{{OP_ACCOUNT}}/{{OP_VAULT}}/{{GH_TOKEN_ITEM}}"')
+
+# Add other secrets the agent needs at runtime here. Examples:
+#
+# @sensitive @required
+# OPENAI_API_KEY=exec('op read "op://{{OP_ACCOUNT}}/{{OP_VAULT}}/openai-api-key"')
+#
+# @sensitive @required
+# DATABASE_URL=exec('op read "op://{{OP_ACCOUNT}}/{{OP_VAULT}}/database-url"')


### PR DESCRIPTION
## Summary

Adds a new skill, `/runway-init`, that scaffolds a target repo for [runway](https://github.com/ValescoAgency/runway) consumption in one shot:

1. Verifies the host has Docker + gh + (Tier 2) varlock + op CLI
2. Runs `npx sandcastle init` to produce `.sandcastle/`
3. Patches `.sandcastle/Dockerfile` with the multi-stage varlock + 1Password CLI + `claude` shim block
4. Scaffolds `.env.schema` at repo root with parameterized `op://` references the user provides
5. Deletes `.sandcastle/.env` so no secret manifest sits at rest
6. Statically verifies the result — no inline secrets, Dockerfile patched, schema declares both required keys

The skill is **advisory**: stages a `chore/runway-init-{ts}` branch and commits, never pushes, never opens a PR. User reviews and ships.

## Layout

```
skills/runway-init/
├── SKILL.md                                     158 lines
├── scripts/
│   ├── 00-preflight.sh                           74 lines
│   ├── 10-sandcastle-init.sh                     38 lines
│   ├── 20-apply-varlock.sh                      119 lines
│   └── 30-verify.sh                              80 lines
└── templates/
    ├── dockerfile-varlock.snippet                33 lines
    └── env.schema.target-repo                    27 lines
```

## Why a skill (vs. just runway shipping a `runway init` command)

- Claude Code can adapt to per-repo quirks (existing Dockerfiles, half-completed setups, monorepo layouts) — pure scripts can't
- The skill is the right place for the "ask the user about their 1Password vault layout" interaction
- Embedded scripts handle the deterministic mechanics; SKILL.md handles the judgment calls

## Tier 1 vs Tier 2

| Tier | What | When |
|---|---|---|
| 1 | `sandcastle init` only — secrets in `.sandcastle/.env` on disk | User has explicitly opted out of varlock |
| 2 | Tier 1 + varlock + 1Password CLI inside the container — zero secrets at rest | **Default.** |

## Test plan

- [x] All four scripts pass `bash -n` syntax check
- [x] `00-preflight.sh --tier=1` runs clean against a fresh empty repo
- [x] `00-preflight.sh --tier=2` correctly detects missing varlock on a host without it
- [ ] End-to-end Tier 2 against a throwaway repo (needs varlock + op CLI installed locally — left as a smoke test for the user)
- [ ] Dockerfile splice point matches latest Sandcastle's generated template (verified against the version in `mattpocock/sandcastle@main` — re-check on Sandcastle bumps)

## Coordination

Templates here vendor the canonical files in [runway/templates/](https://github.com/ValescoAgency/runway/tree/main/templates). When DispatchPayload-shape or varlock conventions change, **bump both repos in lockstep** — drift is a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)