### PR TITLE
feat(skills): add /handoff skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,6 +19,7 @@
     "triage",
     "diagnose",
     "feedback-loop",
+    "handoff",
     "runway"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ the adapter system below.
 | [`/triage`](skills/triage/SKILL.md) | Funnel issues into `Todo` with sharp acceptance criteria so runway will pick them up. HITL-aware. |
 | [`/diagnose`](skills/diagnose/SKILL.md) | Six-phase debugging discipline; Phase 1 builds a deterministic feedback loop. |
 | [`/feedback-loop`](skills/feedback-loop/SKILL.md) | The 10-pattern catalog for constructing deterministic agent-runnable signals. |
+| [`/handoff`](skills/handoff/SKILL.md) | Compact the current conversation into a handoff document so another agent can continue the work. |
 
 ## Tracker adapters
 

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: "What will the next session be used for?"
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save it to a path produced by `mktemp -t handoff-XXXXXX.md` (read the file before you write to it).
+
+Suggest the skills to be used, if any, by the next session.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the document accordingly.


### PR DESCRIPTION
## Summary

- Adds `/handoff` skill that compacts the current conversation into a handoff document at a `mktemp -t handoff-XXXXXX.md` path, so another agent can continue the work.
- Skill references existing artifacts (PRDs, plans, ADRs, issues, commits, diffs) by path/URL instead of duplicating them, and treats arguments as a description of the next session's focus.
- Wires `handoff` into `.claude-plugin/plugin.json` keywords and adds a row to the README skill table.

No version bump or CHANGELOG entry — follows the existing pattern where features accumulate on \`main\` and roll up in a separate \`chore: release X.Y.Z\` PR. \`docs/workflow.md\` intentionally untouched: handoff is a session-management utility, not a stage in the runway funnel.

## Test plan

- [ ] Install/refresh the plugin and confirm \`/handoff\` appears in the skill list.
- [ ] Run \`/handoff\` with no args — confirm a handoff doc is written to a \`mktemp\` path.
- [ ] Run \`/handoff some focus description\` — confirm the doc is tailored to that focus.
- [ ] Verify the README link \`skills/handoff/SKILL.md\` renders on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)