### PR TITLE
fix(handoff): macOS-portable temp path

### DIFF
--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -4,7 +4,7 @@ description: Compact the current conversation into a handoff document for anothe
 argument-hint: "What will the next session be used for?"
 ---
 
-Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save it to a path produced by `mktemp -t handoff-XXXXXX.md` (read the file before you write to it).
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save it to `${TMPDIR:-/tmp}/handoff-$(date +%Y%m%d-%H%M%S).md` (read the file before you write to it).
 
 Suggest the skills to be used, if any, by the next session.
 


### PR DESCRIPTION
## Summary
- BSD `mktemp` (macOS) doesn't expand `XXXXXX` when a suffix follows it. The original `mktemp -t handoff-XXXXXX.md` produced a literal `handoff-XXXXXX.md.<random>` filename — not a valid `.md` path.
- Replace with a portable date-stamped path under `$TMPDIR`. Works the same on macOS and Linux, sortable, and readable.

## Test plan
- [x] Verified BSD `mktemp` failure mode locally (literal `XXXXXX` retained when followed by `.md`).
- [x] Verified `${TMPDIR:-/tmp}/handoff-$(date +%Y%m%d-%H%M%S).md` resolves to a writable path on macOS.
- [ ] Sanity-run `/handoff` in a fresh session after merge to confirm the file lands at the expected path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)