### PR TITLE
feat: labels-as-state queue (1.1.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flightplan",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Valesco-authored Claude Code skills for harness engineering and tracker triage. Vendor-agnostic via the tracker adapter contract — ships with Linear and GitHub Issues adapters. Bundles triage (/triage), debugging discipline (/diagnose), and the feedback-loop pattern catalog (/feedback-loop). Outputs feed runway, Valesco's autonomous coding CLI.",
   "author": {
     "name": "Valesco Agency",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,66 @@ All notable changes to flightplan are documented here. Versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html); breaking
 changes bump the major.
 
+## 1.1.0 — 2026-05-14
+
+`/handoff` skill (added in 1.0.0's merge train but never released) is
+now packaged. The headline change is the **runway queue gate moves from
+status `Todo` to label `ready-for-agent`**.
+
+### Added
+
+- Skill: [`/handoff`](skills/handoff/SKILL.md) — compact the current
+  conversation into a handoff document so another agent can continue
+  the work.
+- State label: `ready-for-agent`. Added to both tracker adapters
+  (`skills/tracker-linear/labels.yml`,
+  `skills/tracker-github/labels.yml`). At most one state label per
+  issue — `ready-for-agent` is mutually exclusive with `needs-info`,
+  `needs-human`, `wontfix`, `needs-triage`.
+
+### Fixed
+
+- `/handoff` temp path is portable on macOS. The original
+  `mktemp -t handoff-XXXXXX.md` produced literal `handoff-XXXXXX.md.<random>`
+  on BSD `mktemp` (any suffix after `X`s blocks expansion). Replaced
+  with `${TMPDIR:-/tmp}/handoff-$(date +%Y%m%d-%H%M%S).md`.
+
+### Changed (BREAKING for runway)
+
+- **Runway queue is now a label, not a status.** runway must drain
+  by `label = ready-for-agent` instead of `status = Todo`. Reason:
+  Linear's GitHub integration auto-mutates status when a PR
+  cross-references an issue (`Triage`/`Backlog`/`Todo` → `In Progress`),
+  silently draining a status-gated queue every time someone mentions an
+  issue in a PR. Labels are not touched by the integration.
+- `/triage` advance transition now applies the `ready-for-agent` label.
+  Status is left to humans + the Linear/GitHub integration, with one
+  exception: if the issue's current status is `Triage` or `Backlog`,
+  `/triage` advances it to `Todo` as a visibility cue. In-flight
+  statuses (`In Progress` / `In Review` / `Reviewed`) are never
+  mutated — read-only-on-active-work invariant preserved.
+- HITL eject (`needs-human`) follows the same status policy.
+
+### Migration notes
+
+Backfill before runway switches its drain query:
+
+1. **Linear**: apply `ready-for-agent` to every issue currently in
+   `Todo` status that you actually want runway to pick up. A Linear
+   saved view filtered by `status = Todo AND has no label
+   ready-for-agent` makes this a one-pass click-through.
+2. **GitHub adapter consumers**: the `ready-for-agent` label will be
+   lazily created on first use via the existing label-creation flow;
+   no manual setup needed.
+3. **Runway**: update the drain query and any state-mutation logic on
+   pickup. Recommended: remove the `ready-for-agent` label as the
+   issue is claimed (atomic claim signal). On run failure, re-apply
+   the label or flip to `needs-human` for triage.
+
+The canonical `todo` status is **not removed** — it's still in the
+state vocabulary and the Linear-native `Todo` is still where humans
+park work. It just no longer gates runway.
+
 ## 1.0.0 — 2026-05-08
 
 First stable release after the pivot away from the AFK governance

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,8 +32,8 @@ PR. Looks for the same things a careful human reviewer would: regressions,
 missing tests, scope creep, brittle patterns. Output goes in the PR body.
 
 **HITL** — *Human In The Loop.* An issue or stage that needs human
-judgment and shouldn't go to runway. Routed to `needs-human` rather than
-`Todo`.
+judgment and shouldn't go to runway. Labeled `needs-human` instead of
+`ready-for-agent`.
 
 ## Tracker domain
 
@@ -71,7 +71,8 @@ protection on this capability.
 
 **Acceptance criteria** — the testable bullets in an issue body that
 runway / Claude Code reads as the spec for what to build. `/triage` makes
-sure these exist and are sharp before transitioning the issue to `Todo`.
+sure these exist and are sharp before applying the `ready-for-agent`
+label.
 
 **Triage Notes** — the comment posted when an issue moves to `needs-info`.
 Lists what's established and the specific facts the reporter needs to
@@ -87,13 +88,19 @@ Vocabulary that consumer skills use unchanged across vendors. Adapters
 translate to/from vendor-native names per `tracker-<provider>/labels.yml`,
 with optional per-repo override at `.afk/tracker-labels.yml`.
 
-**State labels**: `needs-triage`, `needs-info`, `needs-human`, `wontfix`.
+**State labels**: `ready-for-agent`, `needs-triage`, `needs-info`,
+`needs-human`, `wontfix`. At most one per issue (mutually exclusive on
+this axis).
 
 **Category labels**: `Bug`, `Feature`, `Improvement`.
 
 **Status values**: `triage`, `backlog`, `todo`, `in-progress`,
 `in-review`, `done`, `canceled`, `duplicate`.
 
-`Todo` is the runway pickup state — issues in `Todo` with sharp
-acceptance criteria are what runway scans for. `needs-human` is the HITL
-exit; the issue stays open but routes to a human PR rather than runway.
+**`ready-for-agent` is the runway pickup signal.** runway drains issues
+carrying this label. `needs-human` is the HITL exit; the issue stays
+open but routes to a human PR rather than runway. **Status** is owned
+by humans + the tracker's GitHub integration (PR cross-references and
+state transitions drive it automatically). Status is *not* the queue
+gate — using status for the queue caused premature drains every time a
+PR mentioned an issue.

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ After install, skills are invocable as `flightplan:<skill-name>` (e.g.
 ## Consumer skills
 
 User-invoked skills that drive issues toward the runway pickup state
-(tracker `Todo`). Vendor-agnostic — they read the active tracker via
+(label `ready-for-agent`). Vendor-agnostic — they read the active tracker via
 the adapter system below.
 
 | Skill | Purpose |
 |---|---|
-| [`/triage`](skills/triage/SKILL.md) | Funnel issues into `Todo` with sharp acceptance criteria so runway will pick them up. HITL-aware. |
+| [`/triage`](skills/triage/SKILL.md) | Funnel issues to the `ready-for-agent` label with sharp acceptance criteria so runway will pick them up. HITL-aware. |
 | [`/diagnose`](skills/diagnose/SKILL.md) | Six-phase debugging discipline; Phase 1 builds a deterministic feedback loop. |
 | [`/feedback-loop`](skills/feedback-loop/SKILL.md) | The 10-pattern catalog for constructing deterministic agent-runnable signals. |
 | [`/handoff`](skills/handoff/SKILL.md) | Compact the current conversation into a handoff document so another agent can continue the work. |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -26,7 +26,7 @@ idea / conversation / paste
         │
         ├─→ needs-human  → HITL exit (human picks up)
         ├─→ needs-info   → wait for reporter
-        └─→ Todo         (runway pickup state)
+        └─→ ready-for-agent  (label; runway pickup signal)
                 │
                 ▼
         /diagnose           (Valesco — Bugs only; build a deterministic loop)
@@ -37,7 +37,7 @@ idea / conversation / paste
         /grill-with-docs    (optional, when domain alignment looks suspect)
                 │
                 ▼
-   ─── runway picks the issue up from Todo ───────────────────────────
+   ─── runway picks the issue up via the `ready-for-agent` label ────
                 │
                 ▼
    sandcastle (Claude Code in Docker) implements the issue
@@ -49,9 +49,12 @@ idea / conversation / paste
    PR opened on GitHub                    (human reviews + merges)
 ```
 
-The handoff to runway is **the issue body in `Todo`**. Whatever's in the
-issue is what Claude Code sees. So `/triage`'s job is to make sure the
-issue body has clear acceptance criteria before letting it become `Todo`.
+The handoff to runway is **the issue body when `ready-for-agent` is
+applied**. Whatever's in the issue at that moment is what Claude Code
+sees. So `/triage`'s job is to make sure the issue body has clear
+acceptance criteria before applying the label. Status is left to the
+tracker's GitHub integration (PR open → `In Progress`, PR merge →
+`Done`) — it's a useful side effect, not the queue gate.
 
 ## Stage ownership
 
@@ -60,7 +63,7 @@ issue body has clear acceptance criteria before letting it become `Todo`.
 | Idea → aligned plan | [`/grill-with-docs`](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md) | Matt | Alignment + locks domain language in `CONTEXT.md` + records ADRs inline |
 | Plan → PRD | [`/to-prd`](https://github.com/mattpocock/skills/blob/main/skills/engineering/to-prd/SKILL.md) | Matt | Synthesizes a PRD from current context; posts to the tracker |
 | PRD → issues | [`/to-issues`](https://github.com/mattpocock/skills/blob/main/skills/engineering/to-issues/SKILL.md) | Matt | Breaks the PRD into vertical-slice tracer-bullet issues |
-| Tracker issue → Todo | [`/triage`](../skills/triage/SKILL.md) | Valesco | Ensure body has sharp acceptance criteria; transition to `Todo` so runway picks it up; HITL-aware |
+| Tracker issue → `ready-for-agent` | [`/triage`](../skills/triage/SKILL.md) | Valesco | Ensure body has sharp acceptance criteria; apply `ready-for-agent` so runway picks it up; HITL-aware |
 | Bug needs reproducer | [`/diagnose`](../skills/diagnose/SKILL.md) | Valesco | Six-phase loop; Phase 1 builds a deterministic feedback loop |
 | Construct a feedback loop | [`/feedback-loop`](../skills/feedback-loop/SKILL.md) | Valesco | The 10-pattern catalog for deterministic agent-runnable signals |
 | Architecture review | [`/improve-codebase-architecture`](https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/SKILL.md) | Matt | Find deepening opportunities; informed by `CONTEXT.md` + ADRs |
@@ -182,7 +185,7 @@ that gracefully and routing to a human without losing work.
 
 | Trigger | Where it fires | Skill response |
 |---|---|---|
-| Triage decides this needs a human | `/triage` Step 5 | Apply `needs-human`, post a Human Brief explaining why. Status stays out of `Todo` so runway won't grab it. |
+| Triage decides this needs a human | `/triage` Step 5 | Apply `needs-human`, post a Human Brief explaining why. runway drains by `ready-for-agent` label, so an issue tagged `needs-human` (and not `ready-for-agent`) is invisible to runway. |
 | `/diagnose` cannot build a feedback loop | Phase 1 fallback | Drop back to `/triage` with `needs-info` listing the specific blockers. |
 | Sub-agent review surfaces a real concern | runway (not a skill) | runway opens the PR with the concern in the body; the human decides whether to merge or close. |
 

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: diagnose
-description: Disciplined diagnosis loop for hard bugs and performance regressions. Reproduce → hypothesise → instrument → fix → regression-test, with Phase 1 (build a feedback loop) load-bearing. Use when the user says "diagnose this", "debug this", "reproduce this bug", "this is throwing/failing/broken in prod", "why is this slow", or describes a performance regression. Distinct from `/triage` (which decides whether a bug has enough information to be tractable at all). Run this AFTER triage has confirmed the issue is real, BEFORE letting the issue advance to `Todo` for runway — the regression test you write seeds the issue's acceptance criteria and the loop you build proves the fix actually closes the bug.
+description: Disciplined diagnosis loop for hard bugs and performance regressions. Reproduce → hypothesise → instrument → fix → regression-test, with Phase 1 (build a feedback loop) load-bearing. Use when the user says "diagnose this", "debug this", "reproduce this bug", "this is throwing/failing/broken in prod", "why is this slow", or describes a performance regression. Distinct from `/triage` (which decides whether a bug has enough information to be tractable at all). Run this AFTER triage has confirmed the issue is real, BEFORE letting the issue become `ready-for-agent` for runway — the regression test you write seeds the issue's acceptance criteria and the loop you build proves the fix actually closes the bug.
 ---
 
 # /diagnose
@@ -17,7 +17,7 @@ next skill in the chain — see [§ Outputs](#outputs-that-flow-downstream).
 
 After [`/triage`](../triage/SKILL.md) has classified the issue as a `Bug`
 with enough detail to attempt reproduction, but **before** the issue
-advances to `Todo` for runway. An issue that lands in runway without a
+becomes `ready-for-agent` for runway. An issue that lands in runway without a
 concrete reproducer almost always produces a "fix" that passes review
 without proving anything — the regression test you build here pins the
 behavior down.
@@ -236,7 +236,7 @@ issue body itself.
 | New domain term encountered | Update [`CONTEXT.md`](../../docs/workflow.md#contextmd--ubiquitous-language) right there — same discipline as `/grill-with-docs`. Lazy-create the file if it doesn't exist. |
 
 After this skill finishes, the next step is [`/triage`](../triage/SKILL.md)
-to advance the issue to `Todo` (or `needs-human` if the diagnosis surfaced
+to advance the issue to `ready-for-agent` (or `needs-human` if the diagnosis surfaced
 something that runway shouldn't handle).
 
 ## AI disclaimer
@@ -258,7 +258,7 @@ their own provenance via git history.
 
 - **No tracker label transitions.** Status / label moves on the active
   tracker are [`/triage`](../triage/SKILL.md)'s job. This skill may
-  *recommend* a transition (e.g. "looks ready for `Todo`") but applies
+  *recommend* a transition (e.g. "looks ready for `ready-for-agent`") but applies
   nothing itself.
 - **No production instrumentation without explicit user approval.** Phase 4
   logs are local; production probes need the user to say yes.

--- a/skills/feedback-loop/SKILL.md
+++ b/skills/feedback-loop/SKILL.md
@@ -347,7 +347,7 @@ Walk this tree top-to-bottom. Stop at the first "yes."
    (differential).
 10. **Final fallback** — and only after honestly trying 1–9: Pattern 10
     (HITL bash). The loop will not be replayable by an autonomous run, so
-    the issue probably needs `needs-human` rather than `Todo`.
+    the issue probably needs `needs-human` rather than `ready-for-agent`.
 
 If you fall off the bottom of the tree without a fit, the bug isn't
 loopable yet — return to `/triage` and request reproducer access,

--- a/skills/tracker-github/labels.yml
+++ b/skills/tracker-github/labels.yml
@@ -48,6 +48,10 @@ categories:
 # directly; GitHub repos using the flightplan triage funnel will have
 # these labels created on first use via the lazy-create flow.
 state_labels:
+  ready-for-agent:
+    name: ready-for-agent
+    color: "0075ca"
+    description: "Body is sharp enough that runway can pick this up (queue gate)"
   needs-info:
     name: needs-info
     color: "fbca04"

--- a/skills/tracker-linear/labels.yml
+++ b/skills/tracker-linear/labels.yml
@@ -17,6 +17,7 @@ categories:
 
 # State labels — at most one per issue.
 state_labels:
+  ready-for-agent: ready-for-agent  # runway queue gate (the label runway drains on); see CHANGELOG 1.1.0
   needs-info: needs-info
   needs-human: needs-human
   wontfix: wontfix

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -1,26 +1,37 @@
 ---
 name: triage
-description: Funnel tracker issues into `Todo` with sharp acceptance criteria so runway will pick them up. Vendor-agnostic — works with whatever tracker the repo declares (Linear today; GitHub Issues shipped). Use when the user wants to work the inbox, prepare issues for a runway run, decide which issues an agent can take vs. which require a human, or work the Triage queue. Reach for this skill any time the user mentions triaging, classifying, or moving issues toward an autonomous run — even if they don't explicitly say "triage."
+description: Funnel tracker issues to the `ready-for-agent` label with sharp acceptance criteria so runway will pick them up. Vendor-agnostic — works with whatever tracker the repo declares (Linear today; GitHub Issues shipped). Use when the user wants to work the inbox, prepare issues for a runway run, decide which issues an agent can take vs. which require a human, or work the Triage queue. Reach for this skill any time the user mentions triaging, classifying, or moving issues toward an autonomous run — even if they don't explicitly say "triage."
 ---
 
 # /triage — runway funnel
 
 The purpose of this skill is to **prepare tracker issues for runway**.
-runway scans the tracker for issues in `Todo`, hands each one to
-`@ai-hero/sandcastle` (Claude Code in Docker), runs an adversarial
-sub-agent review, and opens a PR. Trust comes from human PR review, not
-from upstream gates.
+runway scans the tracker for issues labeled `ready-for-agent`, hands
+each one to `@ai-hero/sandcastle` (Claude Code in Docker), runs an
+adversarial sub-agent review, and opens a PR. Trust comes from human PR
+review, not from upstream gates.
 
 So every triage decision answers one question:
 
 > *Is this issue body sharp enough that Claude Code, reading nothing but
 > the issue, will produce a PR a human is happy to review?*
 
-If yes → ensure acceptance criteria are present and move the issue to
-`Todo`.
+If yes → ensure acceptance criteria are present and apply the
+`ready-for-agent` label.
 If not yet → identify what's missing and either ask the reporter
 (`needs-info`) or park it (`backlog`).
 If never → eject it cleanly: `needs-human`, `canceled`, or `duplicate`.
+
+### Why the queue is a label, not a status
+
+Linear's GitHub integration auto-mutates issue **status** when a PR
+cross-references the issue (`Triage`/`Backlog`/`Todo` → `In Progress`).
+A status-gated queue drains every time a PR mentions the issue, even
+when runway hasn't picked it up. The queue gate is therefore a
+**label** (`ready-for-agent`) — labels are not touched by the GitHub
+integration. Status remains useful as a human kanban signal and is
+driven naturally by the integration (PR opens → `In Progress`, PR
+merges → `Done`).
 
 The Agent-Brief-as-comment pattern is gone. **runway reads the issue
 body directly** — there's no separate brief artifact for it to consume.
@@ -93,7 +104,7 @@ The skill speaks these values; the adapter maps to vendor-native names.
 |---|---|
 | `triage` | Incoming. Has not been classified or has open questions. |
 | `backlog` | Ejected from active triage but not killed. Will revisit later. |
-| `todo` | **Ready for runway, or marked `needs-human` for a human.** Acceptance criteria are sharp. |
+| `todo` | Human kanban: "this is on deck". Often co-occurs with `ready-for-agent` (runway will pick up) or `needs-human` (a human will pick up), but neither is required — humans may use `todo` for issues outside the runway funnel entirely. |
 | `in-progress` / `in-review` / `reviewed` | Active work. Off-limits to this skill — read-only. |
 | `done` | Closed normally. |
 | `canceled` | Won't fix. Permanent ejection. |
@@ -103,8 +114,9 @@ The skill speaks these values; the adapter maps to vendor-native names.
 
 | Label | Meaning |
 |---|---|
+| `ready-for-agent` | **The runway queue gate.** Body has sharp acceptance criteria; runway will pick this up. Mutually exclusive with the other state labels. |
 | `needs-info` | Specific, named information is missing — without it the issue body isn't sharp enough for runway. Status stays `triage`. |
-| `needs-human` | Cannot become runway-eligible (production access, judgment that doesn't reduce to acceptance criteria, cross-team coordination). Status moves to `Todo` so the human picks it up; runway skips issues carrying this label. |
+| `needs-human` | Cannot become runway-eligible (production access, judgment that doesn't reduce to acceptance criteria, cross-team coordination). A human picks this up; runway skips issues carrying this label. |
 
 ### Category labels (apply exactly one)
 
@@ -123,15 +135,15 @@ The skill speaks these values; the adapter maps to vendor-native names.
 
 ## State machine
 
-The funnel direction is **toward `Todo`**. Each transition either
-advances toward it, parks the issue, or ejects it.
+The funnel direction is **toward the `ready-for-agent` label**. Each
+transition either advances toward it, parks the issue, or ejects it.
 
 | From | To | Direction | Trigger | Action |
 |---|---|---|---|---|
 | New (`triage`, no labels) | + category, stays `triage` | enter | Skill on first look | Apply category, post recommendation comment. |
 | `triage` | + `needs-info` | park | Maintainer (skill) | Specific missing info named. Skill posts Triage Notes with what's blocking. |
-| `triage` / `needs-info` | `todo` (no state label) | **advance** | Maintainer (skill, after grilling) | Skill ensures the issue body has sharp acceptance criteria, removes `needs-info` if present, moves status to `Todo`. runway picks up from here. |
-| `triage` / `needs-info` | `todo` + `needs-human` | eject (HITL) | Maintainer (skill) | Body is sharp but reasons exist not to use runway (production access, judgment calls). Status moves to `Todo`; the `needs-human` label tells runway to skip. |
+| `triage` / `needs-info` | + `ready-for-agent` | **advance** | Maintainer (skill, after grilling) | Skill ensures the issue body has sharp acceptance criteria, removes `needs-info` if present, applies `ready-for-agent`. **Status policy:** if status is currently `triage` or `backlog`, advance to `todo` as a visibility cue; if status is anything past `todo` (active work), leave it alone. The runway queue is keyed on the label, not the status. |
+| `triage` / `needs-info` | + `needs-human` | eject (HITL) | Maintainer (skill) | Body is sharp but reasons exist not to use runway (production access, judgment calls). Applies `needs-human`. Same status policy: advance `triage`/`backlog` → `todo` for visibility; leave active-work statuses alone. runway skips issues carrying `needs-human`. |
 | `triage` / `needs-info` | `backlog` | park | Maintainer (skill) | Acknowledged but deferred. Brief reasoning posted. |
 | `triage` / `needs-info` | `canceled` | eject | Maintainer (skill) | Polite explanation. For `Feature`/`Improvement`, write `.out-of-scope/<concept>.md`. |
 | `triage` / `needs-info` | `duplicate` | eject | Maintainer (skill) | Comment links the canonical issue. |
@@ -150,7 +162,7 @@ Examples:
 - "What's closest to ready for runway?"
 - "Show me what needs attention"
 - "Let's look at issue 87"  (or `VA-87`, or `owner/repo#42` — depends on tracker)
-- "Move issue 42 to Todo"
+- "Mark issue 42 ready for runway" (or the old "Move issue 42 to Todo" — both work)
 - "Anything blocked on the reporter for over a week?"
 
 If the tracker has a team-namespace concept and the namespace is
@@ -252,8 +264,8 @@ reasoning before the issue moves.
 
 | Outcome | Comment to post | Labels | Status |
 |---|---|---|---|
-| Runway-ready | (optional) "Promoting to Todo — runway will pick this up" | + category, − `needs-info` | `todo` |
-| Human-only (HITL) | **Human Brief** — short paragraph explaining *why human, not runway* (production access, judgment, etc.) | + category, + `needs-human`, − `needs-info` | `todo` |
+| Runway-ready | (optional) "Applying `ready-for-agent` — runway will pick this up" | + category, + `ready-for-agent`, − `needs-info` | `todo` if currently `triage`/`backlog`, else untouched |
+| Human-only (HITL) | **Human Brief** — short paragraph explaining *why human, not runway* (production access, judgment, etc.) | + category, + `needs-human`, − `needs-info` | `todo` if currently `triage`/`backlog`, else untouched |
 | `needs-info` | **Triage Notes** — what's established + the *specific* missing facts (template below) | + category, + `needs-info` | `triage` |
 | Won't fix (Bug) | Polite explanation | + `Bug` | `canceled` |
 | Won't fix (Feature/Improvement) | Polite explanation **and** link to the `.out-of-scope/` file | + category | `canceled` |
@@ -277,19 +289,19 @@ performs the calls. Cache resolved IDs within the session.
 
 ## Workflow: quick state override
 
-When the maintainer says "move issue 42 to Todo", trust them. Skip
-grilling.
+When the maintainer says "mark issue 42 ready for runway" (or the
+shorthand "move issue 42 to Todo"), trust them. Skip grilling.
 
 Still confirm before writing:
 
-- Labels to add/remove
-- Status to apply
+- Labels to add/remove (the runway-ready transition adds `ready-for-agent`)
+- Status to apply (per the smart policy: only advance `triage`/`backlog` → `todo`)
 - Whether to post a comment, and what kind
 
-For `Todo` without prior grilling, ask once: "The issue body looks like
-[summary]. Sharp enough for runway, or want to flesh it out first?" If
-the body is genuinely thin, runway will produce a thin PR — say so and
-let the maintainer decide.
+For a runway-ready transition without prior grilling, ask once: "The
+issue body looks like [summary]. Sharp enough for runway, or want to
+flesh it out first?" If the body is genuinely thin, runway will produce
+a thin PR — say so and let the maintainer decide.
 
 ## Needs-info template
 
@@ -308,7 +320,7 @@ they're answered.
 - point 1
 - point 2
 
-**What we need before this can move to Todo (@<reporter>):**
+**What we need before this can be picked up by runway (@<reporter>):**
 
 - A specific success criterion, e.g. "When X happens, the user should
   see Y" — what's the testable outcome?
@@ -343,4 +355,4 @@ When triaging an issue with prior triage activity:
 - [`../diagnose/SKILL.md`](../diagnose/SKILL.md) — downstream Bug
   reproduction skill.
 - [`runway`](https://github.com/ValescoAgency/runway) — what picks the
-  issue up once it's in `Todo`.
+  issue up once it's labeled `ready-for-agent`.


### PR DESCRIPTION
## Summary
- Move the runway queue gate from Linear status \`Todo\` to a new state label \`ready-for-agent\`. Reason: Linear's GitHub integration auto-mutates status when a PR cross-references an issue (\`Triage\`/\`Backlog\`/\`Todo\` → \`In Progress\`), silently draining a status-gated queue every time someone mentions an issue in a PR. Labels are not touched by the integration.
- \`/triage\` advance + HITL transitions now apply labels for queue control; status is only nudged \`Triage\`/\`Backlog\` → \`Todo\` as a visibility cue (in-flight statuses left alone — read-only-on-active-work preserved).
- Formally packages the previously-merged \`/handoff\` skill in this release.
- Bumps plugin to **1.1.0**.

## Files

| File | Change |
|---|---|
| \`CHANGELOG.md\` | 1.1.0 entry with loud migration notes |
| \`.claude-plugin/plugin.json\` | \`1.0.0\` → \`1.1.0\` |
| \`CONTEXT.md\` | \`ready-for-agent\` added to state-label vocabulary; canonical state machine rewritten |
| \`docs/workflow.md\` | Diagram + Stage-ownership + HITL-fork tables updated |
| \`README.md\` | Triage description + adapter blurb updated |
| \`skills/triage/SKILL.md\` | State machine, Step 5 outcome table, Quick state override, explainer |
| \`skills/diagnose/SKILL.md\` | Handoff language updated |
| \`skills/feedback-loop/SKILL.md\` | One \`Todo\` reference updated |
| \`skills/tracker-linear/labels.yml\` | \`ready-for-agent\` added to state_labels |
| \`skills/tracker-github/labels.yml\` | \`ready-for-agent\` added to state_labels with color/description |

## Breaking change

Runway must update its drain query: \`status = Todo\` → \`label = ready-for-agent\`. See CHANGELOG § Migration notes.

## Test plan
- [ ] Backfill existing Linear \`Todo\` issues with \`ready-for-agent\` (one-pass click-through via saved view)
- [ ] Run \`/triage\` on a fresh issue end-to-end — confirm \`ready-for-agent\` is applied and status is bumped to \`Todo\` only if starting from \`Triage\`/\`Backlog\`
- [ ] Confirm a PR cross-reference no longer drains the queue (cross-reference an issue with \`ready-for-agent\` from a PR, verify the label survives the status flip to \`In Progress\`)
- [ ] Update runway's drain query in a follow-up PR
- [ ] Sanity-check \`/diagnose\` handoff language reads naturally

> Depends on / supersedes #31 — the \`/handoff\` macOS fix from #31 lands here too via the CHANGELOG's "Fixed" section. If #31 is merged first, this PR's CHANGELOG entry remains accurate; if not, this PR will need a small follow-up to re-apply the mktemp fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)